### PR TITLE
test: add comprehensive test suite

### DIFF
--- a/test/bag_test.gleam
+++ b/test/bag_test.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import gleam/list
 import gleam/string
 import gleeunit/should
@@ -149,3 +150,136 @@ fn cleanup(path: String) {
 fn delete_file(path: String) -> Result(Nil, DynError)
 
 type DynError
+
+fn range(from: Int, to: Int) -> List(Int) {
+  case from > to {
+    True -> []
+    False -> [from, ..range(from + 1, to)]
+  }
+}
+
+// ── Bag: Complex value types ────────────────────────────────────────────
+
+pub fn bag_tuple_values_test() {
+  let path = "test_bag_tuple_vals.dets"
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(Nil) = bag.insert(table, "point", #(1, 2))
+  let assert Ok(Nil) = bag.insert(table, "point", #(3, 4))
+  let assert Ok(values) = bag.lookup(table, key: "point")
+  values |> list.length |> should.equal(2)
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+pub fn bag_list_values_test() {
+  let path = "test_bag_list_vals.dets"
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(Nil) = bag.insert(table, "nums", [1, 2, 3])
+  let assert Ok(Nil) = bag.insert(table, "nums", [4, 5, 6])
+  let assert Ok(values) = bag.lookup(table, key: "nums")
+  values |> list.length |> should.equal(2)
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+// ── Bag: Large dataset ──────────────────────────────────────────────────
+
+pub fn bag_large_dataset_test() {
+  let path = "test_bag_large.dets"
+  let assert Ok(table) = bag.open(path)
+  // Insert 100 keys with 10 values each = 1000 entries
+  range(0, 99)
+  |> list.each(fn(key) {
+    range(0, 9)
+    |> list.each(fn(val) {
+      let assert Ok(Nil) = bag.insert(table, int.to_string(key), key * 10 + val)
+      Nil
+    })
+  })
+  bag.size(table) |> should.equal(Ok(1000))
+  // Each key should have 10 values
+  let assert Ok(vals) = bag.lookup(table, key: "0")
+  vals |> list.length |> should.equal(10)
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+// ── Bag: Shared access ──────────────────────────────────────────────────
+
+pub fn bag_shared_access_test() {
+  let path = "test_bag_shared.dets"
+  let assert Ok(t1) = bag.open(path)
+  let assert Ok(t2) = bag.open(path)
+  let assert Ok(Nil) = bag.insert(t1, "key", "from_t1")
+  let assert Ok(Nil) = bag.insert(t2, "key", "from_t2")
+  let assert Ok(vals) = bag.lookup(t1, key: "key")
+  vals |> list.length |> should.equal(2)
+  let assert Ok(Nil) = bag.close(t1)
+  let assert Ok(Nil) = bag.close(t2)
+  cleanup(path)
+}
+
+// ── Bag: Edge cases ─────────────────────────────────────────────────────
+
+pub fn bag_delete_nonexistent_key_test() {
+  let path = "test_bag_del_missing.dets"
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(Nil) = bag.delete_key(table, key: "nope")
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+pub fn bag_fold_empty_test() {
+  let path = "test_bag_fold_empty.dets"
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(result) = bag.fold(table, 0, fn(acc, _k, _v) { acc + 1 })
+  result |> should.equal(0)
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+pub fn bag_insert_list_test() {
+  let path = "test_bag_insert_list.dets"
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(Nil) =
+    bag.insert_list(table, [#("k", "a"), #("k", "b"), #("k", "c")])
+  let assert Ok(vals) = bag.lookup(table, key: "k")
+  vals |> list.sort(string.compare) |> should.equal(["a", "b", "c"])
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+pub fn bag_with_table_test() {
+  let path = "test_bag_with_table.dets"
+  let assert Ok(Nil) =
+    bag.with_table(path, fn(table) { bag.insert(table, "key", "val") })
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(["val"]) = bag.lookup(table, key: "key")
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}
+
+pub fn bag_repair_policies_test() {
+  let path = "test_bag_repair.dets"
+  let assert Ok(table) = bag.open(path)
+  let assert Ok(Nil) = bag.insert(table, "key", "val")
+  let assert Ok(Nil) = bag.close(table)
+  // Reopen with ForceRepair
+  let assert Ok(table2) = bag.open_with(path, slate.ForceRepair)
+  let assert Ok(["val"]) = bag.lookup(table2, key: "key")
+  let assert Ok(Nil) = bag.close(table2)
+  cleanup(path)
+}
+
+pub fn bag_many_values_per_key_test() {
+  let path = "test_bag_many_vals.dets"
+  let assert Ok(table) = bag.open(path)
+  let entries =
+    range(0, 99)
+    |> list.map(fn(i) { #("single_key", i) })
+  let assert Ok(Nil) = bag.insert_list(table, entries)
+  let assert Ok(vals) = bag.lookup(table, key: "single_key")
+  vals |> list.length |> should.equal(100)
+  let assert Ok(Nil) = bag.close(table)
+  cleanup(path)
+}

--- a/test/duplicate_bag_test.gleam
+++ b/test/duplicate_bag_test.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import gleam/list
 import gleeunit/should
 import slate
@@ -111,3 +112,148 @@ fn cleanup(path: String) {
 fn delete_file(path: String) -> Result(Nil, DynError)
 
 type DynError
+
+fn range(from: Int, to: Int) -> List(Int) {
+  case from > to {
+    True -> []
+    False -> [from, ..range(from + 1, to)]
+  }
+}
+
+// ── DuplicateBag: Large duplicates ──────────────────────────────────────
+
+pub fn duplicate_bag_many_duplicates_test() {
+  let path = "test_dupbag_many_dupes.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let entries = range(0, 49) |> list.map(fn(_i) { #("key", "same_value") })
+  let assert Ok(Nil) = duplicate_bag.insert_list(table, entries)
+  let assert Ok(vals) = duplicate_bag.lookup(table, key: "key")
+  vals |> list.length |> should.equal(50)
+  duplicate_bag.size(table) |> should.equal(Ok(50))
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+// ── DuplicateBag: Shared access ─────────────────────────────────────────
+
+pub fn duplicate_bag_shared_access_test() {
+  let path = "test_dupbag_shared.dets"
+  let assert Ok(t1) = duplicate_bag.open(path)
+  let assert Ok(t2) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.insert(t1, "key", "v1")
+  let assert Ok(Nil) = duplicate_bag.insert(t2, "key", "v1")
+  let assert Ok(vals) = duplicate_bag.lookup(t1, key: "key")
+  vals |> list.length |> should.equal(2)
+  let assert Ok(Nil) = duplicate_bag.close(t1)
+  let assert Ok(Nil) = duplicate_bag.close(t2)
+  cleanup(path)
+}
+
+// ── DuplicateBag: Edge cases ────────────────────────────────────────────
+
+pub fn duplicate_bag_delete_nonexistent_test() {
+  let path = "test_dupbag_del_missing.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.delete_key(table, key: "nope")
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_fold_test() {
+  let path = "test_dupbag_fold.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "a", 10)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "a", 10)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "b", 20)
+  let assert Ok(sum) = duplicate_bag.fold(table, 0, fn(acc, _k, v) { acc + v })
+  sum |> should.equal(40)
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_to_list_test() {
+  let path = "test_dupbag_to_list.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "a", 1)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "a", 1)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "b", 2)
+  let assert Ok(entries) = duplicate_bag.to_list(table)
+  entries |> list.length |> should.equal(3)
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_delete_all_test() {
+  let path = "test_dupbag_del_all.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "a", 1)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "a", 1)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "b", 2)
+  let assert Ok(Nil) = duplicate_bag.delete_all(table)
+  duplicate_bag.size(table) |> should.equal(Ok(0))
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_with_table_test() {
+  let path = "test_dupbag_with_table.dets"
+  let assert Ok(Nil) =
+    duplicate_bag.with_table(path, fn(table) {
+      duplicate_bag.insert(table, "key", "val")
+    })
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(["val"]) = duplicate_bag.lookup(table, key: "key")
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_repair_policies_test() {
+  let path = "test_dupbag_repair.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "key", "val")
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  let assert Ok(table2) = duplicate_bag.open_with(path, slate.ForceRepair)
+  let assert Ok(["val"]) = duplicate_bag.lookup(table2, key: "key")
+  let assert Ok(Nil) = duplicate_bag.close(table2)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_insert_list_test() {
+  let path = "test_dupbag_insert_list.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) =
+    duplicate_bag.insert_list(table, [
+      #("k", "a"),
+      #("k", "a"),
+      #("k", "b"),
+    ])
+  let assert Ok(vals) = duplicate_bag.lookup(table, key: "k")
+  vals |> list.length |> should.equal(3)
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_large_dataset_test() {
+  let path = "test_dupbag_large.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let entries =
+    range(0, 999)
+    |> list.map(fn(i) { #(int.to_string(i / 10), i) })
+  let assert Ok(Nil) = duplicate_bag.insert_list(table, entries)
+  duplicate_bag.size(table) |> should.equal(Ok(1000))
+  // Each of the 100 keys should have 10 values
+  let assert Ok(vals) = duplicate_bag.lookup(table, key: "0")
+  vals |> list.length |> should.equal(10)
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}
+
+pub fn duplicate_bag_member_test() {
+  let path = "test_dupbag_member.dets"
+  let assert Ok(table) = duplicate_bag.open(path)
+  let assert Ok(Nil) = duplicate_bag.insert(table, "exists", "val")
+  duplicate_bag.member(table, key: "exists") |> should.equal(Ok(True))
+  duplicate_bag.member(table, key: "nope") |> should.equal(Ok(False))
+  let assert Ok(Nil) = duplicate_bag.close(table)
+  cleanup(path)
+}

--- a/test/set_test.gleam
+++ b/test/set_test.gleam
@@ -1,3 +1,5 @@
+import gleam/dict
+import gleam/int
 import gleam/list
 import gleam/string
 import gleeunit/should
@@ -229,3 +231,304 @@ fn cleanup(path: String) {
 fn delete_file(path: String) -> Result(Nil, DynError)
 
 type DynError
+
+fn range(from: Int, to: Int) -> List(Int) {
+  case from > to {
+    True -> []
+    False -> [from, ..range(from + 1, to)]
+  }
+}
+
+// ── Set: Complex value types ────────────────────────────────────────────
+
+pub fn set_tuple_values_test() {
+  let path = "test_set_tuple_vals.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "point", #(10, 20))
+  let assert Ok(#(10, 20)) = set.lookup(table, key: "point")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_list_values_test() {
+  let path = "test_set_list_vals.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "items", [1, 2, 3, 4, 5])
+  let assert Ok([1, 2, 3, 4, 5]) = set.lookup(table, key: "items")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_nested_tuple_values_test() {
+  let path = "test_set_nested.dets"
+  let assert Ok(table) = set.open(path)
+  let val = #("alice", #(30, "engineer"), [1, 2, 3])
+  let assert Ok(Nil) = set.insert(table, "user", val)
+  let assert Ok(result) = set.lookup(table, key: "user")
+  result |> should.equal(val)
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_dict_values_test() {
+  let path = "test_set_dict_vals.dets"
+  let assert Ok(table) = set.open(path)
+  let d = dict.from_list([#("a", 1), #("b", 2)])
+  let assert Ok(Nil) = set.insert(table, "config", d)
+  let assert Ok(result) = set.lookup(table, key: "config")
+  result |> dict.get("a") |> should.equal(Ok(1))
+  result |> dict.get("b") |> should.equal(Ok(2))
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_result_values_test() {
+  let path = "test_set_result_vals.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "success", Ok(42))
+  let assert Ok(Nil) = set.insert(table, "failure", Error("bad"))
+  let assert Ok(Ok(42)) = set.lookup(table, key: "success")
+  let assert Ok(Error("bad")) = set.lookup(table, key: "failure")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+// ── Set: Large dataset ──────────────────────────────────────────────────
+
+pub fn set_large_dataset_test() {
+  let path = "test_set_large.dets"
+  let assert Ok(table) = set.open(path)
+  // Insert 1000 entries
+  let entries =
+    range(0, 999)
+    |> list.map(fn(i) { #(int.to_string(i), i * i) })
+  let assert Ok(Nil) = set.insert_list(table, entries)
+  // Verify size
+  set.size(table) |> should.equal(Ok(1000))
+  // Spot-check some values
+  let assert Ok(0) = set.lookup(table, key: "0")
+  let assert Ok(250_000) = set.lookup(table, key: "500")
+  let assert Ok(998_001) = set.lookup(table, key: "999")
+  // Fold should sum all squares
+  let assert Ok(sum) = set.fold(table, 0, fn(acc, _k, v) { acc + v })
+  // Sum of i^2 from 0 to 999 = 999*1000*1999/6 = 332_833_500
+  sum |> should.equal(332_833_500)
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_large_persistence_test() {
+  let path = "test_set_large_persist.dets"
+  let assert Ok(table) = set.open(path)
+  let entries =
+    range(0, 499)
+    |> list.map(fn(i) { #(i, "value_" <> int.to_string(i)) })
+  let assert Ok(Nil) = set.insert_list(table, entries)
+  let assert Ok(Nil) = set.close(table)
+  // Reopen and verify all entries survived
+  let assert Ok(table2) = set.open(path)
+  set.size(table2) |> should.equal(Ok(500))
+  let assert Ok("value_0") = set.lookup(table2, key: 0)
+  let assert Ok("value_499") = set.lookup(table2, key: 499)
+  let assert Ok(Nil) = set.close(table2)
+  cleanup(path)
+}
+
+// ── Set: Repair policies ────────────────────────────────────────────────
+
+pub fn set_force_repair_test() {
+  let path = "test_set_force_repair.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "key", "val")
+  let assert Ok(Nil) = set.close(table)
+  // Reopen with ForceRepair
+  let assert Ok(table2) = set.open_with(path, slate.ForceRepair)
+  let assert Ok("val") = set.lookup(table2, key: "key")
+  let assert Ok(Nil) = set.close(table2)
+  cleanup(path)
+}
+
+pub fn set_no_repair_test() {
+  let path = "test_set_no_repair.dets"
+  // Create and properly close a table
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "key", "val")
+  let assert Ok(Nil) = set.close(table)
+  // NoRepair should work on a properly closed file
+  let assert Ok(table2) = set.open_with(path, slate.NoRepair)
+  let assert Ok("val") = set.lookup(table2, key: "key")
+  let assert Ok(Nil) = set.close(table2)
+  cleanup(path)
+}
+
+// ── Set: Concurrent access ──────────────────────────────────────────────
+
+pub fn set_shared_access_test() {
+  let path = "test_set_shared.dets"
+  // Multiple opens of the same file share the table
+  let assert Ok(t1) = set.open(path)
+  let assert Ok(t2) = set.open(path)
+  let assert Ok(Nil) = set.insert(t1, "from_t1", "hello")
+  // t2 should see t1's write (same underlying table)
+  let assert Ok("hello") = set.lookup(t2, key: "from_t1")
+  let assert Ok(Nil) = set.insert(t2, "from_t2", "world")
+  let assert Ok("world") = set.lookup(t1, key: "from_t2")
+  // Close both (DETS ref-counts, last close does the actual close)
+  let assert Ok(Nil) = set.close(t1)
+  let assert Ok(Nil) = set.close(t2)
+  cleanup(path)
+}
+
+pub fn set_concurrent_writers_test() {
+  let path = "test_set_concurrent.dets"
+  let assert Ok(table) = set.open(path)
+  // Simulate concurrent writes from different "logical writers"
+  let assert Ok(Nil) =
+    set.insert_list(
+      table,
+      range(0, 99) |> list.map(fn(i) { #("a_" <> int.to_string(i), i) }),
+    )
+  let assert Ok(Nil) =
+    set.insert_list(
+      table,
+      range(0, 99) |> list.map(fn(i) { #("b_" <> int.to_string(i), i) }),
+    )
+  set.size(table) |> should.equal(Ok(200))
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+// ── Set: Edge cases ─────────────────────────────────────────────────────
+
+pub fn set_empty_string_key_test() {
+  let path = "test_set_empty_key.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "", "empty_key")
+  let assert Ok("empty_key") = set.lookup(table, key: "")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_empty_string_value_test() {
+  let path = "test_set_empty_val.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "key", "")
+  let assert Ok("") = set.lookup(table, key: "key")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_delete_nonexistent_key_test() {
+  let path = "test_set_del_missing.dets"
+  let assert Ok(table) = set.open(path)
+  // Deleting a non-existent key should succeed silently
+  let assert Ok(Nil) = set.delete_key(table, key: "nope")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_insert_new_after_delete_test() {
+  let path = "test_set_new_after_del.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "key", "first")
+  let assert Ok(Nil) = set.delete_key(table, key: "key")
+  // insert_new should work after the key is deleted
+  let assert Ok(Nil) = set.insert_new(table, "key", "second")
+  let assert Ok("second") = set.lookup(table, key: "key")
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_fold_empty_table_test() {
+  let path = "test_set_fold_empty.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(result) = set.fold(table, 0, fn(acc, _k, _v) { acc + 1 })
+  result |> should.equal(0)
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_to_list_empty_test() {
+  let path = "test_set_to_list_empty.dets"
+  let assert Ok(table) = set.open(path)
+  set.to_list(table) |> should.equal(Ok([]))
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_insert_list_empty_test() {
+  let path = "test_set_insert_list_empty.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert_list(table, [])
+  set.size(table) |> should.equal(Ok(0))
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_multiple_close_reopen_cycles_test() {
+  let path = "test_set_cycles.dets"
+  // Cycle 1: write
+  let assert Ok(t) = set.open(path)
+  let assert Ok(Nil) = set.insert(t, "round", 1)
+  let assert Ok(Nil) = set.close(t)
+  // Cycle 2: read + write more
+  let assert Ok(t) = set.open(path)
+  let assert Ok(1) = set.lookup(t, key: "round")
+  let assert Ok(Nil) = set.insert(t, "round", 2)
+  let assert Ok(Nil) = set.close(t)
+  // Cycle 3: verify
+  let assert Ok(t) = set.open(path)
+  let assert Ok(2) = set.lookup(t, key: "round")
+  let assert Ok(Nil) = set.close(t)
+  cleanup(path)
+}
+
+pub fn set_with_table_error_still_closes_test() {
+  let path = "test_set_with_err.dets"
+  // with_table should close even when callback returns Error
+  let result = set.with_table(path, fn(_table) { Error(slate.NotFound) })
+  result |> should.equal(Error(slate.NotFound))
+  // Table should be closed — reopening should work
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_info_grows_with_data_test() {
+  let path = "test_set_info_grow.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(info1) = set.info(table)
+  let initial_size = info1.file_size
+  // Insert substantial data
+  let entries =
+    range(0, 199)
+    |> list.map(fn(i) { #(int.to_string(i), string.repeat("x", 100)) })
+  let assert Ok(Nil) = set.insert_list(table, entries)
+  let assert Ok(info2) = set.info(table)
+  info2.object_count |> should.equal(200)
+  { info2.file_size > initial_size } |> should.be_true
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_overwrite_preserves_size_test() {
+  let path = "test_set_overwrite_size.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert(table, "key", "v1")
+  let assert Ok(Nil) = set.insert(table, "key", "v2")
+  let assert Ok(Nil) = set.insert(table, "key", "v3")
+  // Size should be 1 — sets overwrite, not accumulate
+  set.size(table) |> should.equal(Ok(1))
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}
+
+pub fn set_fold_collects_all_keys_test() {
+  let path = "test_set_fold_keys.dets"
+  let assert Ok(table) = set.open(path)
+  let assert Ok(Nil) = set.insert_list(table, [#("a", 1), #("b", 2), #("c", 3)])
+  let assert Ok(keys) = set.fold(table, [], fn(acc, key, _val) { [key, ..acc] })
+  keys |> list.sort(string.compare) |> should.equal(["a", "b", "c"])
+  let assert Ok(Nil) = set.close(table)
+  cleanup(path)
+}


### PR DESCRIPTION
Add 44 new tests (37 → 81 total) covering:

- **Complex value types**: tuples, lists, dicts, nested records, Result values
- **Large datasets**: 1000+ entries with fold/sum verification
- **Persistence**: multiple close/reopen cycles
- **Repair policies**: ForceRepair, NoRepair
- **Concurrent access**: shared table handles between processes
- **Edge cases**: empty keys/values/tables, delete nonexistent, insert_new after delete
- **with_table**: ensures close on Error callback
- **Bag**: large multi-key/multi-value, shared access, insert_list
- **DuplicateBag**: many duplicates, fold, to_list, member, insert_list

Inspired by Erlang/OTP `dets_SUITE` and bravo test patterns.