### PR TITLE
ci(pr): trigger title validation on edits

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
   changelog:
     name: Changelog
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft != true
+    if: github.event.pull_request.draft != true && github.event.action != 'edited'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:


### PR DESCRIPTION
The PR validation workflow was missing the `edited` event type, so the title validation job never re-ran when a PR title was updated.

### Changes

- Add `edited` to the `pull_request` trigger types in `pr.yml`
- Add `github.event.action != 'edited'` condition to the changelog job so it skips on title/body edits