### PR TITLE
docs: add changelog entry for initial 0.1.0 release

### DIFF
--- a/.changes/unreleased/Added-20260306-140559.yaml
+++ b/.changes/unreleased/Added-20260306-140559.yaml
@@ -1,0 +1,11 @@
+kind: Added
+body: |-
+    Initial release of slate, a type-safe Gleam wrapper for Erlang DETS.
+
+    - Set tables with unique keys and insert/lookup/delete operations
+    - Bag tables supporting multiple distinct values per key
+    - Duplicate bag tables allowing duplicate key-value pairs
+    - Safe resource management with `with_table` helper
+    - Comprehensive error handling via Gleam Result types
+    - Configurable repair policies (auto, force, none)
+time: 2026-03-06T14:05:59.499972-08:00


### PR DESCRIPTION
## Summary

- Add changie changelog entry for the initial 0.1.0 release of slate
- Covers all initial features: set/bag/duplicate_bag tables, `with_table` helper, Result-based error handling, and configurable repair policies

## Test plan

- [x] Verify changie entry is valid YAML
- [ ] Run `changie batch 0.1.0` to confirm entry batches correctly