### PR TITLE
docs: use native admonition syntax in md files

### DIFF
--- a/website/src/content/docs/advanced/error-handling.md
+++ b/website/src/content/docs/advanced/error-handling.md
@@ -3,8 +3,6 @@ title: Error Handling
 description: Understanding and handling errors in slate.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
 All slate functions return `Result` types — they never raise exceptions. Errors are represented by the `DetsError` type defined in the `slate` module.
 
 ## Error types
@@ -21,9 +19,9 @@ let assert Ok(table) = set.open("data/users.dets")
 let assert Error(slate.NotFound) = set.lookup(table, key: "nonexistent")
 ```
 
-<Aside type="note">
+:::note
 Bag and duplicate bag tables return an empty list instead of `NotFound` when a key is missing. Only set tables return this error from `lookup`.
-</Aside>
+:::
 
 ### `KeyAlreadyPresent`
 

--- a/website/src/content/docs/advanced/limitations.md
+++ b/website/src/content/docs/advanced/limitations.md
@@ -3,17 +3,15 @@ title: Limitations
 description: Known limitations of DETS and slate.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
 slate wraps Erlang's [DETS](https://www.erlang.org/doc/apps/stdlib/dets.html), which has several inherent limitations. Understanding these helps you choose the right storage approach.
 
 ## File size limit
 
 DETS tables are limited to **2 GB** per file. This is a hard limit in the DETS implementation and cannot be configured. If a table exceeds this size, operations will return `Error(FileSizeLimitExceeded)`.
 
-<Aside type="tip">
+:::tip
 If you need more than 2 GB of storage, consider splitting data across multiple tables, or using a database like SQLite or Postgres.
-</Aside>
+:::
 
 ## No `ordered_set` table type
 
@@ -23,9 +21,9 @@ Unlike Erlang's ETS (in-memory storage), DETS does not support `ordered_set` tab
 
 DETS performs disk I/O on every read and write. This makes it unsuitable for high-frequency operations where latency matters. For performance-critical reads, consider loading data into ETS at startup and using DETS only for persistence.
 
-<Aside type="note">
+:::note
 The related library [shelf](https://github.com/tylerbutler/shelf) automates this pattern — it provides persistent ETS tables backed by DETS, giving you microsecond reads with durable storage.
-</Aside>
+:::
 
 ## Tables must be closed properly
 

--- a/website/src/content/docs/advanced/with-table.md
+++ b/website/src/content/docs/advanced/with-table.md
@@ -3,8 +3,6 @@ title: Safe Resource Management
 description: Using with_table for automatic table lifecycle management.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
 DETS tables must be properly closed to ensure data is flushed to disk. If a table is not closed — for example, because an error occurs — pending writes may be lost and the file may need repair on next open.
 
 The `with_table` function solves this by automatically closing the table when your callback returns, whether it succeeds or fails.
@@ -107,9 +105,9 @@ let assert Ok(_) = duplicate_bag.with_table("data/dup.dets", fn(table) { ... })
 
 ## When to use `with_table`
 
-<Aside type="tip">
+:::tip
 Use `with_table` for short-lived operations — lookups, inserts, or quick computations. For long-lived tables that stay open for the lifetime of your application, use `open`/`close` directly and manage the lifecycle yourself.
-</Aside>
+:::
 
 | Scenario | Recommended |
 |----------|-------------|

--- a/website/src/content/docs/guides/set-tables.md
+++ b/website/src/content/docs/guides/set-tables.md
@@ -3,8 +3,6 @@ title: Set Tables
 description: Unique key-value storage with DETS set tables.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
-
 Set tables store key-value pairs where each key maps to exactly one value. Inserting with an existing key overwrites the previous value. This is the most common table type, ideal for caches, configuration, and general-purpose persistence.
 
 Set tables are provided by the `slate/set` module and correspond to the `set` table type in Erlang's [DETS](https://www.erlang.org/doc/apps/stdlib/dets.html).
@@ -46,9 +44,9 @@ let assert Ok(Nil) = set.insert_new(table, "alice", 42)
 let assert Error(slate.KeyAlreadyPresent) = set.insert_new(table, "alice", 99)
 ```
 
-<Aside type="note">
+:::note
 `insert_new` is only available on set tables. Bag and duplicate bag tables do not have this function.
-</Aside>
+:::
 
 ## Looking up data
 
@@ -101,9 +99,9 @@ let assert Ok(3) = set.update_counter(table, "page_views", 2)
 let assert Ok(1) = set.update_counter(table, "page_views", -2)
 ```
 
-<Aside type="note">
+:::note
 `update_counter` is only available on set tables, and requires the value to be an integer.
-</Aside>
+:::
 
 ## Flushing writes
 


### PR DESCRIPTION
Replace `<Aside>` JSX component imports with Starlight's native `:::note` and `:::tip` admonition syntax in `.md` files, where JSX imports are not supported.

### Changes

- **advanced/with-table.md** — removed import, replaced 1 `<Aside type="tip">`
- **advanced/limitations.md** — removed import, replaced 1 tip + 1 note
- **advanced/error-handling.md** — removed import, replaced 1 note
- **guides/set-tables.md** — removed import, replaced 2 notes