### PR TITLE
feat(changelog): add Breaking kind with minor version bump

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -19,6 +19,8 @@ body:
 kinds:
     - label: Added
       auto: minor
+    - label: Breaking
+      auto: minor
     - label: Changed
       auto: patch
     - label: Deprecated


### PR DESCRIPTION
## Summary

- Adds a `Breaking` kind to `.changie.yaml` for API/behavior changes that break backwards compatibility
- Configured with `auto: minor` to bump the minor version on release (same as `Added`)

## Motivation

Previously there was no way to distinguish a breaking change from a regular `Changed` entry. The new kind makes it explicit in the changelog and ensures breaking changes trigger a minor version bump rather than patch.