### PR TITLE
ci: allow uppercase characters in commit subjects

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -19,7 +19,7 @@
       ]
     ],
     "scope-case": [2, "always", "lower-case"],
-    "subject-case": [2, "always", "lower-case"],
+    "subject-case": [0],
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
     "header-max-length": [2, "always", 72],


### PR DESCRIPTION
Disables the `subject-case` commitlint rule so PR titles and commit subjects can use any casing (e.g., `docs: Add type-level doc comment`).