### PR TITLE
ci: use changie content for GitHub Release notes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -12,4 +12,4 @@ jobs:
   auto-tag:
     uses: tylerbutler/actions/.github/workflows/auto-tag.yml@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
-      create-release: false
+      create-release: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,32 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Create GitHub Release
+      - name: Check for existing release
+        id: check
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" --generate-notes
+        run: |
+          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        if: steps.check.outputs.exists == 'false'
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          NOTES_FILE=".changes/${TAG}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --notes-file "$NOTES_FILE"
+          else
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --generate-notes
+          fi
 
   publish:
     needs: test


### PR DESCRIPTION
## Summary

Use changie-generated content for GitHub Release notes instead of auto-generated git commit notes.

## Changes

### `auto-tag.yml`
- Set `create-release: true` so the `changie-auto-tag` action creates a GitHub Release using `.changes/{version}.md` as the release body when it tags a merged release PR.

### `publish.yml`
- Added a check for an existing release before creating one (avoids conflict with the release created by `auto-tag`).
- When no release exists (e.g., manual tag push), creates one using `.changes/{tag}.md` if available, falling back to `--generate-notes`.

## Release flow

| Path | Release created by | Notes source |
|---|---|---|
| Release PR merged → auto-tag → tag push | `auto-tag.yml` | `.changes/{version}.md` |
| Manual tag push | `publish.yml` (fallback) | `.changes/{tag}.md` or `--generate-notes` |
