### PR TITLE
docs: remove pre-1.0 warnings from website

### DIFF
--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -16,11 +16,7 @@ hero:
       variant: secondary
 ---
 
-import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
-
-<Aside type="caution" title="Pre-1.0 Software">
-slate is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
-</Aside>
+import { Card, CardGrid } from '@astrojs/starlight/components';
 
 ## Features
 

--- a/website/src/content/docs/installation.md
+++ b/website/src/content/docs/installation.md
@@ -3,10 +3,6 @@ title: Installation
 description: How to install slate in your Gleam project.
 ---
 
-:::caution[Pre-1.0 Software]
-slate is not yet 1.0. The API is unstable and features may be removed in minor releases.
-:::
-
 Add slate to your Gleam project:
 
 ```bash

--- a/website/src/content/docs/introduction.md
+++ b/website/src/content/docs/introduction.md
@@ -3,10 +3,6 @@ title: What is slate?
 description: An introduction to slate and DETS.
 ---
 
-:::caution[Pre-1.0 Software]
-slate is not yet 1.0. The API is unstable, features may be removed in minor releases, and quality should not be considered production-ready. We welcome usage and feedback in the meantime!
-:::
-
 slate is a **type-safe Gleam wrapper** for Erlang's [DETS](https://www.erlang.org/doc/apps/stdlib/dets.html) (Disk Erlang Term Storage). It provides persistent key-value storage backed by files on disk, with a clean Gleam API.
 
 ## Why slate?

--- a/website/src/content/docs/quick-start.md
+++ b/website/src/content/docs/quick-start.md
@@ -3,10 +3,6 @@ title: Quick Start
 description: Get up and running with slate in minutes.
 ---
 
-:::caution[Pre-1.0 Software]
-slate is not yet 1.0. The API is unstable and features may be removed in minor releases.
-:::
-
 This guide walks you through basic DETS operations with slate.
 
 ## 1. Add slate to your project


### PR DESCRIPTION
## Summary
- Remove `:::caution[Pre-1.0 Software]` admonitions from introduction, quick-start, and installation pages
- Remove `<Aside>` caution block from the landing page (`index.mdx`)
- Clean up unused `Aside` import from `index.mdx`

Closes #28

## Test plan
- [ ] Verify website builds without errors
- [ ] Check that the four affected pages render correctly without the caution blocks