### PR TITLE
docs: resize logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![slate logo](https://slate.tylerbutler.com/slate.webp)
+<img src="https://slate.tylerbutler.com/slate.webp" alt="slate logo" width="200">
 
 # slate
 


### PR DESCRIPTION
## Summary
- Use HTML `img` tag with `width="200"` to control logo size in README

## Test plan
- [ ] Verify logo renders at correct size on GitHub