### PR TITLE
ci: always build production Netlify deploys from main

### DIFF
--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -3,3 +3,7 @@
   publish = "dist"
   # Only trigger builds when files in website/ change.
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- website/"
+
+# Always build production deploys from main.
+[context.production]
+  ignore = "/bin/false"


### PR DESCRIPTION
## Summary

- The `ignore` rule in `netlify.toml` was causing Netlify to skip production deploys when no files in `website/` changed between commits.
- Adds a `[context.production]` override with `ignore = "/bin/false"` so main-branch deploys always run, while branch/PR deploy previews still skip when docs haven't changed.

## Test plan

- [ ] Merge to main and verify Netlify triggers a production deploy automatically