### PR TITLE
ci: use conventional commit format for release PR titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+          pr-title-template: 'chore(release): {version}'
           version-files: |
             gleam.toml:version
 


### PR DESCRIPTION
## Summary

- The changie-release action defaults to `Release {version}` for PR titles, which fails the commitlint validation in `pr.yml`.
- Overrides `pr-title-template` with `chore(release): {version}` to pass conventional commit checks.

## Test plan

- [ ] Merge and verify next release PR is titled `chore(release): vX.Y.Z`