### PR TITLE
fix(ci): add v prefix to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -12,4 +12,5 @@ jobs:
   auto-tag:
     uses: tylerbutler/actions/.github/workflows/auto-tag.yml@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
+      tag-prefix: v
       create-release: true


### PR DESCRIPTION
## Summary
- The auto-tag workflow was creating tags without the `v` prefix (e.g. `1.0.0`), but `publish.yml` triggers on `v*` tags
- Passes `tag-prefix: v` to the reusable workflow so future releases create `v1.0.0`-style tags

## Test plan
- [x] Verified the 1.0.0 release failed to trigger publish due to missing prefix
- [x] Next release should create a `v`-prefixed tag automatically