### PR TITLE
docs: fix error handling and troubleshooting accuracy

### DIFF
--- a/.changes/unreleased/Fixed-20260424-182854.yaml
+++ b/.changes/unreleased/Fixed-20260424-182854.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: 'Correct documentation inaccuracies in error handling and troubleshooting guides: replace non-existent `ErlangError` with `UnexpectedError`, fix non-existent `delete` references to `delete_key`, add missing decoder arguments to all `open` examples, and document previously-omitted error variants (`NotADetsFile`, `NeedsRepair`, `DecodeErrors`, `TableNamePoolExhausted`, `UnexpectedError`, `set.UpdateCounterError`).'
-time: 2026-04-24T18:28:54.106001667-07:00

--- a/.changes/unreleased/Fixed-20260424-182854.yaml
+++ b/.changes/unreleased/Fixed-20260424-182854.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Correct documentation inaccuracies in error handling and troubleshooting guides: replace non-existent `ErlangError` with `UnexpectedError`, fix non-existent `delete` references to `delete_key`, add missing decoder arguments to all `open` examples, and document previously-omitted error variants (`NotADetsFile`, `NeedsRepair`, `DecodeErrors`, `TableNamePoolExhausted`, `UnexpectedError`, `set.UpdateCounterError`).'
+time: 2026-04-24T18:28:54.106001667-07:00

--- a/src/slate.gleam
+++ b/src/slate.gleam
@@ -19,7 +19,7 @@
 /// let assert Ok(table) = set.open("data/cache.dets",
 ///   key_decoder: decode.string, value_decoder: decode.string)
 /// let assert Ok(Nil) = set.insert(table, "key", "value")
-/// let assert Ok(value) = set.lookup(table, "key")
+/// let assert Ok(value) = set.lookup(table, key: "key")
 /// let assert Ok(Nil) = set.close(table)
 /// ```
 ///

--- a/website/src/content/docs/advanced/error-handling.md
+++ b/website/src/content/docs/advanced/error-handling.md
@@ -3,46 +3,43 @@ title: Error Handling
 description: Understanding and handling errors in slate.
 ---
 
-All slate functions return `Result` types — they never raise exceptions. Errors are represented by the `DetsError` type defined in the `slate` module.
+All slate functions return `Result` types — they never raise exceptions. Most errors are represented by the `DetsError` type defined in the `slate` module. The single exception is `slate/set.update_counter`, which returns `Result(_, set.UpdateCounterError)` so it can carry the counter-specific `CounterValueNotInteger` case.
 
-## Error types
+For a stable machine-readable code or a user-facing message, use [`slate.error_code`](/advanced/troubleshooting/#using-error_code-and-error_message) and `slate.error_message`.
+
+## Error variants
 
 ### `NotFound`
 
-Returned when looking up a key that does not exist in a set table.
+Returned by `set.lookup` when the key does not exist. Bag and duplicate bag tables return `Ok([])` instead — see [Lookup behavior differences](/advanced/troubleshooting/#lookup-behavior-differences).
 
 ```gleam
+import gleam/dynamic/decode
 import slate
 import slate/set
 
-let assert Ok(table) = set.open("data/users.dets")
+let assert Ok(table) = set.open("data/users.dets",
+  key_decoder: decode.string, value_decoder: decode.int)
 let assert Error(slate.NotFound) = set.lookup(table, key: "nonexistent")
 ```
 
-:::note
-Bag and duplicate bag tables return an empty list instead of `NotFound` when a key is missing. Only set tables return this error from `lookup`.
-:::
-
 ### `KeyAlreadyPresent`
 
-Returned by `insert_new` when the key (set) or exact key-value pair (bag) already exists.
+Returned by `set.insert_new` when the key exists, and by `bag.insert_new` when the exact key-value pair already exists. Plain `insert` never returns this — it overwrites (set) or silently ignores duplicates (bag).
 
 ```gleam
-import slate
-import slate/set
-
 let assert Ok(Nil) = set.insert_new(table, "alice", 42)
 let assert Error(slate.KeyAlreadyPresent) = set.insert_new(table, "alice", 99)
 ```
 
 ### `AccessDenied`
 
-Returned when attempting a write operation on a table opened with `ReadOnly` access.
+Returned when a write is attempted on a table opened with `ReadOnly` access.
 
 ```gleam
-import slate
-import slate/set
+import gleam/dynamic/decode
 import slate.{AutoRepair, ReadOnly}
+import slate/set
 
 let assert Ok(table) = set.open_with_access(path: "data/users.dets",
   repair: AutoRepair, access: ReadOnly,
@@ -52,78 +49,120 @@ let assert Error(slate.AccessDenied) = set.insert(table, "key", "value")
 
 ### `TypeMismatch`
 
-Returned when opening a DETS file as a different table type than it was created with. For example, opening a set file as a bag.
+Returned when opening a DETS file as a different table type than it was created with — for example, opening a set file as a bag.
 
 ```gleam
+import gleam/dynamic/decode
 import slate
-import slate/set
 import slate/bag
+import slate/set
 
 // Create a set table
-let assert Ok(table) = set.open("data/store.dets")
+let assert Ok(table) = set.open("data/store.dets",
+  key_decoder: decode.string, value_decoder: decode.string)
 let assert Ok(Nil) = set.insert(table, "key", "value")
 let assert Ok(Nil) = set.close(table)
 
 // Try to open the same file as a bag — fails
-let assert Error(slate.TypeMismatch) = bag.open("data/store.dets")
+let assert Error(slate.TypeMismatch) = bag.open("data/store.dets",
+  key_decoder: decode.string, value_decoder: decode.string)
 ```
 
 ### `FileNotFound`
 
-Returned when the DETS file cannot be found or accessed. This can occur when the file path is invalid or the file system denies access.
+The DETS file could not be found or accessed. Returned by the `open*` functions when the path is invalid or the file system denies access.
+
+### `NotADetsFile`
+
+The path exists and is readable, but the file is not a valid DETS file. Use [`slate.is_dets_file`](/advanced/limitations/#validating-dets-files) to check before opening if you accept untrusted paths.
+
+### `NeedsRepair`
+
+The file was not closed cleanly and you opened it with `NoRepair`. Reopen with `AutoRepair` or `ForceRepair` to recover. See [Repair policies](/advanced/troubleshooting/#repair-policies).
 
 ### `AlreadyOpen`
 
-Returned when trying to open a table that is already open with a different configuration.
+The table is already open with an incompatible configuration (for example, different access mode).
 
 ### `TableDoesNotExist`
 
-Returned when performing an operation on a table handle that is no longer valid — for example, after the table has been closed.
+The table handle is no longer valid — typically because `close` was already called.
 
 ### `FileSizeLimitExceeded`
 
-Returned when an operation would cause the DETS file to exceed the 2 GB size limit. See [Limitations](/advanced/limitations/) for details.
+A write would push the DETS file past its 2 GB hard limit. See [Limitations](/advanced/limitations/#file-size-limit) for context and mitigations.
 
-### `ErlangError(String)`
+### `TableNamePoolExhausted`
 
-A catch-all for unexpected Erlang-level errors. The string contains a formatted description of the underlying Erlang error. If you encounter this error, it may indicate a bug — please [report it](https://github.com/tylerbutler/slate/issues).
+slate uses a bounded internal pool of DETS table name slots. If too many distinct files are open at once, new opens fail with this error. See [Troubleshooting](/advanced/troubleshooting/#tablenamepoolexhausted) for recovery steps.
+
+### `DecodeErrors(List(decode.DecodeError))`
+
+The data on disk did not match the decoders provided when opening the table. See [DecodeErrors](/advanced/troubleshooting/#decodeerrors) for diagnosis and recovery strategies.
+
+### `UnexpectedError(String)`
+
+A catch-all for unexpected Erlang-level errors. The wrapped string is for diagnostics only and is **not** part of slate's stable API contract. Use `slate.error_code(err)` (which returns `"unexpected_error"`) for programmatic matching, and report a [GitHub issue](https://github.com/tylerbutler/slate/issues) if you encounter one.
+
+## `set.update_counter` errors
+
+`update_counter` returns `Result(Int, set.UpdateCounterError)` rather than `DetsError`. The dedicated type adds one operation-specific case without polluting the shared error type:
+
+```gleam
+import slate
+import slate/set
+
+case set.update_counter(table, key: "hits", increment: 1) {
+  Ok(new_value) -> new_value
+  Error(set.CounterValueNotInteger) -> 0
+  Error(set.TableError(slate.NotFound)) -> 0
+  Error(set.TableError(err)) -> panic as slate.error_message(err)
+}
+```
 
 ## Handling errors
 
 ### Pattern matching
 
-Use Gleam's pattern matching to handle specific errors:
+Match on the variants you expect in normal flows; fall through to a generic branch for the rest:
 
 ```gleam
+import gleam/io
 import slate
 import slate/set
 
 case set.lookup(table, key: "config") {
   Ok(value) -> io.println("Found: " <> value)
   Error(slate.NotFound) -> io.println("Key not found, using default")
-  Error(other) -> io.println("Unexpected error")
+  Error(other) ->
+    io.println("[" <> slate.error_code(other) <> "] " <> slate.error_message(other))
 }
 ```
 
 ### Using `let assert`
 
-For cases where you expect the operation to succeed, use `let assert` to crash on failure. This is common in scripts, tests, and initialization code:
+For paths where you expect success, `let assert` keeps initialization and test code concise:
 
 ```gleam
-let assert Ok(table) = set.open("data/cache.dets")
+let assert Ok(table) = set.open("data/cache.dets",
+  key_decoder: decode.string, value_decoder: decode.string)
 let assert Ok(Nil) = set.insert(table, "key", "value")
 ```
 
 ## Error summary
 
-| Error | Cause | Affected Functions |
-|-------|-------|--------------------|
-| `NotFound` | Key missing (set tables only) | `lookup` |
-| `KeyAlreadyPresent` | Key or pair exists | `insert_new` (set, bag) |
+| Error | Cause | Typical functions |
+|-------|-------|-------------------|
+| `NotFound` | Key missing (set tables only) | `set.lookup`, `set.update_counter` (via `TableError`) |
+| `KeyAlreadyPresent` | Key (set) or exact pair (bag) already exists | `insert_new` (set, bag) |
 | `AccessDenied` | Write on read-only table | `insert`, `insert_list`, `insert_new`, `delete_*`, `update_counter` |
 | `TypeMismatch` | Wrong table type for file | `open`, `open_with`, `open_with_access` |
-| `FileNotFound` | File missing or inaccessible | `open`, `open_with`, `open_with_access` |
-| `AlreadyOpen` | Table open with different config | `open`, `open_with`, `open_with_access` |
-| `TableDoesNotExist` | Invalid table handle | Most operations |
-| `FileSizeLimitExceeded` | File would exceed 2 GB | Write operations |
-| `ErlangError(msg)` | Unexpected Erlang error | Any |
+| `FileNotFound` | File missing or inaccessible | `open*`, `is_dets_file` |
+| `NotADetsFile` | Path exists but is not a DETS file | `open*`, `is_dets_file` |
+| `NeedsRepair` | File not closed cleanly, opened with `NoRepair` | `open_with`, `open_with_access` |
+| `AlreadyOpen` | Table open with different config | `open*` |
+| `TableDoesNotExist` | Invalid table handle (already closed) | Most operations |
+| `FileSizeLimitExceeded` | Write would exceed 2 GB | Write operations |
+| `TableNamePoolExhausted` | Too many tables open at once | `open*` |
+| `DecodeErrors(_)` | On-disk data did not match decoders | Read operations |
+| `UnexpectedError(_)` | Unexpected Erlang-level error | Any |

--- a/website/src/content/docs/advanced/troubleshooting.md
+++ b/website/src/content/docs/advanced/troubleshooting.md
@@ -101,7 +101,7 @@ case set.open_with(path: "data/important.dets", repair: NoRepair,
 
 ## TableNamePoolExhausted
 
-Slate uses a fixed internal pool of 4096 DETS table name slots. Each unique file path that you open consumes one slot. When all slots are in use, `open` returns `TableNamePoolExhausted`.
+slate uses a fixed internal pool of 4096 DETS table name slots. Each unique file path that you open consumes one slot. When all slots are in use, `open` returns `TableNamePoolExhausted`.
 
 ### Why it happens
 
@@ -178,7 +178,7 @@ This difference matters when you branch on "key exists vs. key missing." With se
 
 ## delete_object for duplicate_bag
 
-The `delete` function removes *all* values associated with a key. In contrast, `delete_object` removes only the exact key-value pair you specify. This distinction is most useful with duplicate bag tables, where a single key can have multiple values — including duplicates.
+The `delete_key` function removes *all* values associated with a key. In contrast, `delete_object` removes only the exact key-value pair you specify. This distinction is most useful with duplicate bag tables, where a single key can have multiple values — including duplicates.
 
 ### Example
 
@@ -192,8 +192,8 @@ let assert Ok(Nil) = duplicate_bag.delete_object(table, key: "color", value: "re
 // Now contains only: ("color", "blue")
 // Both copies of ("color", "red") were removed
 
-// To remove all values for a key regardless of value, use delete instead
-let assert Ok(Nil) = duplicate_bag.delete(table, key: "color")
+// To remove all values for a key regardless of value, use delete_key instead
+let assert Ok(Nil) = duplicate_bag.delete_key(table, key: "color")
 // Now contains nothing for "color"
 ```
 
@@ -203,11 +203,11 @@ let assert Ok(Nil) = duplicate_bag.delete(table, key: "color")
 
 For **bag** tables, `delete_object` works the same way — it removes the specific key-value pair. Since bag tables do not store duplicate pairs, one call is always sufficient.
 
-For **set** tables, `delete_object` removes the entry only if both the key *and* value match what is stored. If you only want to delete by key regardless of value, use `delete` instead.
+For **set** tables, `delete_object` removes the entry only if both the key *and* value match what is stored. If you only want to delete by key regardless of value, use `delete_key` instead.
 
 ## Using error_code and error_message
 
-Slate provides two helper functions for working with errors programmatically:
+slate provides two helper functions for working with errors programmatically:
 
 - **`slate.error_code(error)`** returns a stable, machine-readable string like `"not_found"` or `"decode_error"`. Use this for logging, metrics, and programmatic error handling.
 - **`slate.error_message(error)`** returns a human-readable description like `"No value was found for the requested key."` Use this for user-facing messages and debug output.


### PR DESCRIPTION
## Summary

Documentation review of the website's developer-facing pages and inline module docs surfaced several accuracy bugs that would mislead or block developers. This PR fixes them.

## Bugs fixed

**Non-existent symbols referenced in examples**

- `error-handling.md` referenced an `ErlangError(String)` variant that does not exist. The actual variant is `UnexpectedError(String)`.
- `troubleshooting.md` called a `delete` function (e.g., `duplicate_bag.delete(table, key: "color")`) that does not exist. The actual function is `delete_key`.

**Examples that don't type-check**

Every `set.open(...)` / `bag.open(...)` example in `error-handling.md` omitted the required `key_decoder:` and `value_decoder:` arguments. Copy-pasted, none of them would compile.

**Incomplete error catalog**

The "Error Handling" page omitted several `DetsError` variants: `NotADetsFile`, `NeedsRepair`, `DecodeErrors`, `TableNamePoolExhausted`, and `UnexpectedError`. It also did not mention `set.UpdateCounterError` (the dedicated error type returned by `set.update_counter`).

**Misleading description of `KeyAlreadyPresent`**

The page said `KeyAlreadyPresent` is returned by `insert_new` "when the key (set) or exact key-value pair (bag) already exists" — which conflated `bag.insert` (silent no-op for duplicates) with `bag.insert_new` (the function that actually returns this error). Source of truth: `src/slate/bag.gleam:268-278` and `test/bag_test.gleam:26-40`.

## Polish

- Lowercased "Slate" → "slate" in `troubleshooting.md` to match the README, splash page, and every other doc.
- Standardized the top-level `slate.gleam` quickstart snippet to use the labelled `key:` argument in `set.lookup`, matching every other example.

## Verification

- `just check` — passes
- `npm run check:astro` (in `website/`) — 0 errors, 0 warnings
- `npm run build:site` (in `website/`) — builds, all internal links valid
