### PR TITLE
fix: render module docs and apply Gleam style review cleanup

### DIFF
--- a/.changes/unreleased/Fixed-20260724-015451.yaml
+++ b/.changes/unreleased/Fixed-20260724-015451.yaml
@@ -1,0 +1,12 @@
+kind: Fixed
+body: |-
+    Module documentation now renders on HexDocs.
+
+    Module-level doc comments used `///` instead of `////`, so the package and
+    module docs (including the Quick Start and Limitations sections) were
+    silently dropped from generated documentation.
+
+    Also includes non-breaking style cleanup from a Gleam conventions review:
+    qualified imports and full type annotations in the test suite, hardened
+    test assertions, and clearer internal names. No public API changes.
+time: 2026-07-24T01:54:51.000000+00:00

--- a/src/slate.gleam
+++ b/src/slate.gleam
@@ -1,37 +1,38 @@
-/// Type-safe Gleam wrapper for Erlang DETS (Disk Erlang Term Storage).
-///
-/// DETS provides persistent key-value storage backed by files on disk.
-/// Tables survive process crashes and node restarts. DETS is built into
-/// OTP — no external database or dependency is needed.
-///
-/// ## Table Types
-///
-/// - `slate/set` — Unique keys, one value per key
-/// - `slate/bag` — Multiple distinct values per key
-/// - `slate/duplicate_bag` — Multiple values per key (duplicates allowed)
-///
-/// ## Quick Start
-///
-/// ```gleam
-/// import gleam/dynamic/decode
-/// import slate/set
-///
-/// let assert Ok(table) = set.open("data/cache.dets",
-///   key_decoder: decode.string, value_decoder: decode.string)
-/// let assert Ok(Nil) = set.insert(table, "key", "value")
-/// let assert Ok(value) = set.lookup(table, key: "key")
-/// let assert Ok(Nil) = set.close(table)
-/// ```
-///
-/// ## Limitations
-///
-/// - 2 GB maximum file size
-/// - No `ordered_set` table type (unlike ETS)
-/// - Disk I/O on every operation (use ETS for high-frequency reads)
-/// - Tables must be closed properly or data may be lost
-/// - **Bounded table name pool**: slate uses a bounded set of internal
-///   DETS table names to avoid unbounded atom growth. Opening too many
-///   distinct tables at once may fail; close unused tables promptly
+//// Type-safe Gleam wrapper for Erlang DETS (Disk Erlang Term Storage).
+////
+//// DETS provides persistent key-value storage backed by files on disk.
+//// Tables survive process crashes and node restarts. DETS is built into
+//// OTP — no external database or dependency is needed.
+////
+//// ## Table Types
+////
+//// - `slate/set` — Unique keys, one value per key
+//// - `slate/bag` — Multiple distinct values per key
+//// - `slate/duplicate_bag` — Multiple values per key (duplicates allowed)
+////
+//// ## Quick Start
+////
+//// ```gleam
+//// import gleam/dynamic/decode
+//// import slate/set
+////
+//// let assert Ok(table) = set.open("data/cache.dets",
+////   key_decoder: decode.string, value_decoder: decode.string)
+//// let assert Ok(Nil) = set.insert(table, "key", "value")
+//// let assert Ok(value) = set.lookup(table, key: "key")
+//// let assert Ok(Nil) = set.close(table)
+//// ```
+////
+//// ## Limitations
+////
+//// - 2 GB maximum file size
+//// - No `ordered_set` table type (unlike ETS)
+//// - Disk I/O on every operation (use ETS for high-frequency reads)
+//// - Tables must be closed properly or data may be lost
+//// - **Bounded table name pool**: slate uses a bounded set of internal
+////   DETS table names to avoid unbounded atom growth. Opening too many
+////   distinct tables at once may fail; close unused tables promptly
+
 import gleam/dynamic/decode
 
 /// Errors that can occur during DETS operations.

--- a/src/slate/bag.gleam
+++ b/src/slate/bag.gleam
@@ -1,23 +1,24 @@
-/// DETS bag tables — multiple distinct values per key.
-///
-/// Bag tables allow storing multiple values for the same key. Duplicate
-/// key-value pairs are silently ignored by `insert`. Use `insert_new`
-/// when you need to detect duplicates.
-///
-/// ## Example
-///
-/// ```gleam
-/// import gleam/dynamic/decode
-/// import slate/bag
-///
-/// let assert Ok(table) = bag.open("tags.dets",
-///   key_decoder: decode.string, value_decoder: decode.string)
-/// let assert Ok(Nil) = bag.insert(table, "color", "red")
-/// let assert Ok(Nil) = bag.insert(table, "color", "blue")
-/// let assert Ok(["red", "blue"]) = bag.lookup(table, "color")
-/// let assert Ok(Nil) = bag.close(table)
-/// ```
-///
+//// DETS bag tables — multiple distinct values per key.
+////
+//// Bag tables allow storing multiple values for the same key. Duplicate
+//// key-value pairs are silently ignored by `insert`. Use `insert_new`
+//// when you need to detect duplicates.
+////
+//// ## Example
+////
+//// ```gleam
+//// import gleam/dynamic/decode
+//// import slate/bag
+////
+//// let assert Ok(table) = bag.open("tags.dets",
+////   key_decoder: decode.string, value_decoder: decode.string)
+//// let assert Ok(Nil) = bag.insert(table, "color", "red")
+//// let assert Ok(Nil) = bag.insert(table, "color", "blue")
+//// let assert Ok(["red", "blue"]) = bag.lookup(table, "color")
+//// let assert Ok(Nil) = bag.close(table)
+//// ```
+////
+
 import gleam/dynamic/decode.{type Decoder, type Dynamic}
 import gleam/list
 import gleam/result
@@ -158,8 +159,8 @@ pub fn with_table(
 pub fn lookup(from table: Bag(k, v), key key: k) -> Result(List(v), DetsError) {
   case ffi_lookup_all(table.ref, key) {
     Ok(dynamic_values) ->
-      list.try_map(dynamic_values, fn(dv) {
-        decode.run(dv, table.value_decoder)
+      list.try_map(dynamic_values, fn(dynamic_value) {
+        decode.run(dynamic_value, table.value_decoder)
         |> result.map_error(slate.DecodeErrors)
       })
     Error(err) -> Error(err)

--- a/src/slate/duplicate_bag.gleam
+++ b/src/slate/duplicate_bag.gleam
@@ -1,23 +1,24 @@
-/// DETS duplicate bag tables — multiple values per key, duplicates allowed.
-///
-/// Duplicate bag tables are like bag tables but allow storing identical
-/// key-value pairs multiple times.
-///
-/// ## Example
-///
-/// ```gleam
-/// import gleam/dynamic/decode
-/// import slate/duplicate_bag
-///
-/// let assert Ok(table) = duplicate_bag.open("events.dets",
-///   key_decoder: decode.string, value_decoder: decode.string)
-/// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "button_a")
-/// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "button_a")
-/// let assert Ok(["button_a", "button_a"]) =
-///   duplicate_bag.lookup(table, "click")
-/// let assert Ok(Nil) = duplicate_bag.close(table)
-/// ```
-///
+//// DETS duplicate bag tables — multiple values per key, duplicates allowed.
+////
+//// Duplicate bag tables are like bag tables but allow storing identical
+//// key-value pairs multiple times.
+////
+//// ## Example
+////
+//// ```gleam
+//// import gleam/dynamic/decode
+//// import slate/duplicate_bag
+////
+//// let assert Ok(table) = duplicate_bag.open("events.dets",
+////   key_decoder: decode.string, value_decoder: decode.string)
+//// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "button_a")
+//// let assert Ok(Nil) = duplicate_bag.insert(table, "click", "button_a")
+//// let assert Ok(["button_a", "button_a"]) =
+////   duplicate_bag.lookup(table, "click")
+//// let assert Ok(Nil) = duplicate_bag.close(table)
+//// ```
+////
+
 import gleam/dynamic/decode.{type Decoder, type Dynamic}
 import gleam/list
 import gleam/result
@@ -165,8 +166,8 @@ pub fn lookup(
 ) -> Result(List(v), DetsError) {
   case ffi_lookup_all(table.ref, key) {
     Ok(dynamic_values) ->
-      list.try_map(dynamic_values, fn(dv) {
-        decode.run(dv, table.value_decoder)
+      list.try_map(dynamic_values, fn(dynamic_value) {
+        decode.run(dynamic_value, table.value_decoder)
         |> result.map_error(slate.DecodeErrors)
       })
     Error(err) -> Error(err)

--- a/src/slate/internal.gleam
+++ b/src/slate/internal.gleam
@@ -1,6 +1,7 @@
-/// Internal shared utilities for slate table modules.
-///
-/// This module is not part of the public API.
+//// Internal shared utilities for slate table modules.
+////
+//// This module is not part of the public API.
+
 import gleam/dynamic/decode.{type Decoder, type Dynamic}
 import gleam/list
 import gleam/result

--- a/src/slate/set.gleam
+++ b/src/slate/set.gleam
@@ -1,21 +1,22 @@
-/// DETS set tables — one value per key.
-///
-/// Set tables store key-value pairs where each key maps to exactly one value.
-/// Inserting with an existing key overwrites the previous value.
-///
-/// ## Example
-///
-/// ```gleam
-/// import gleam/dynamic/decode
-/// import slate/set
-///
-/// let assert Ok(table) = set.open("users.dets",
-///   key_decoder: decode.string, value_decoder: decode.int)
-/// let assert Ok(Nil) = set.insert(table, "alice", 42)
-/// let assert Ok(42) = set.lookup(table, "alice")
-/// let assert Ok(Nil) = set.close(table)
-/// ```
-///
+//// DETS set tables — one value per key.
+////
+//// Set tables store key-value pairs where each key maps to exactly one value.
+//// Inserting with an existing key overwrites the previous value.
+////
+//// ## Example
+////
+//// ```gleam
+//// import gleam/dynamic/decode
+//// import slate/set
+////
+//// let assert Ok(table) = set.open("users.dets",
+////   key_decoder: decode.string, value_decoder: decode.int)
+//// let assert Ok(Nil) = set.insert(table, "alice", 42)
+//// let assert Ok(42) = set.lookup(table, "alice")
+//// let assert Ok(Nil) = set.close(table)
+//// ```
+////
+
 import gleam/dynamic/decode.{type Decoder, type Dynamic}
 
 import gleam/result

--- a/test/access_mode_test.gleam
+++ b/test/access_mode_test.gleam
@@ -1,5 +1,6 @@
-/// Tests for read-only access mode.
-/// Adapted from OTP dets_SUITE access/1 test.
+//// Tests for read-only access mode.
+//// Adapted from OTP dets_SUITE access/1 test.
+
 import gleam/dynamic/decode
 import gleam/list
 import gleam/string
@@ -8,11 +9,11 @@ import slate/bag
 import slate/duplicate_bag
 import slate/set
 import startest/expect
-import test_helpers.{cleanup}
+import test_helpers
 
 // ── Set: read-only prevents writes ──────────────────────────────────────
 
-pub fn set_readonly_lookup_test() {
+pub fn set_readonly_lookup_test() -> Nil {
   let path = "test_set_ro_lookup.dets"
   // First create and populate
   let assert Ok(table) =
@@ -33,10 +34,10 @@ pub fn set_readonly_lookup_test() {
   set.member(ro, key: "key") |> expect.to_equal(Ok(True))
   set.size(ro) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_insert_fails_test() {
+pub fn set_readonly_insert_fails_test() -> Nil {
   let path = "test_set_ro_insert.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -52,10 +53,10 @@ pub fn set_readonly_insert_fails_test() {
   let result = set.insert(ro, "new_key", "val")
   result |> expect.to_equal(Error(slate.AccessDenied))
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_delete_fails_test() {
+pub fn set_readonly_delete_fails_test() -> Nil {
   let path = "test_set_ro_delete.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -74,10 +75,10 @@ pub fn set_readonly_delete_fails_test() {
   // Key should still exist
   let assert Ok("val") = set.lookup(ro, key: "key")
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_delete_all_fails_test() {
+pub fn set_readonly_delete_all_fails_test() -> Nil {
   let path = "test_set_ro_del_all.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -97,10 +98,10 @@ pub fn set_readonly_delete_all_fails_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok("val") = set.lookup(rw, key: "key")
   let assert Ok(Nil) = set.close(rw)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_insert_new_fails_test() {
+pub fn set_readonly_insert_new_fails_test() -> Nil {
   let path = "test_set_ro_insert_new.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -116,10 +117,10 @@ pub fn set_readonly_insert_new_fails_test() {
   let result = set.insert_new(ro, "key", "val")
   result |> expect.to_equal(Error(slate.AccessDenied))
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_fold_works_test() {
+pub fn set_readonly_fold_works_test() -> Nil {
   let path = "test_set_ro_fold.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -137,10 +138,10 @@ pub fn set_readonly_fold_works_test() {
   let assert Ok(sum) = set.fold(ro, 0, fn(acc, _k, v) { acc + v })
   sum |> expect.to_equal(3)
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_to_list_works_test() {
+pub fn set_readonly_to_list_works_test() -> Nil {
   let path = "test_set_ro_to_list.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -157,10 +158,10 @@ pub fn set_readonly_to_list_works_test() {
   let assert Ok(entries) = set.to_list(ro)
   entries |> expect.to_equal([#("a", 1)])
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_info_works_test() {
+pub fn set_readonly_info_works_test() -> Nil {
   let path = "test_set_ro_info.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -177,10 +178,10 @@ pub fn set_readonly_info_works_test() {
   let assert Ok(info) = set.info(ro)
   info.object_count |> expect.to_equal(1)
   let assert Ok(Nil) = set.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_readonly_nonexistent_file_fails_test() {
+pub fn set_readonly_nonexistent_file_fails_test() -> Nil {
   let path = "test_set_ro_nofile.dets"
   // Opening a non-existent file as read-only should fail
   let result =
@@ -195,7 +196,7 @@ pub fn set_readonly_nonexistent_file_fails_test() {
     Error(_) -> Nil
     Ok(table) -> {
       let assert Ok(Nil) = set.close(table)
-      cleanup(path)
+      test_helpers.cleanup(path)
       panic as "should have failed to open non-existent file as read-only"
     }
   }
@@ -203,7 +204,7 @@ pub fn set_readonly_nonexistent_file_fails_test() {
 
 // ── Bag: read-only ──────────────────────────────────────────────────────
 
-pub fn bag_readonly_lookup_test() {
+pub fn bag_readonly_lookup_test() -> Nil {
   let path = "test_bag_ro_lookup.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -223,10 +224,10 @@ pub fn bag_readonly_lookup_test() {
   |> list.sort(string.compare)
   |> expect.to_equal(["a", "b"])
   let assert Ok(Nil) = bag.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_readonly_insert_fails_test() {
+pub fn bag_readonly_insert_fails_test() -> Nil {
   let path = "test_bag_ro_insert.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -242,10 +243,10 @@ pub fn bag_readonly_insert_fails_test() {
   let result = bag.insert(ro, "k", "v")
   result |> expect.to_equal(Error(slate.AccessDenied))
   let assert Ok(Nil) = bag.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_readonly_delete_fails_test() {
+pub fn bag_readonly_delete_fails_test() -> Nil {
   let path = "test_bag_ro_delete.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -262,10 +263,10 @@ pub fn bag_readonly_delete_fails_test() {
   let result = bag.delete_key(ro, key: "k")
   result |> expect.to_equal(Error(slate.AccessDenied))
   let assert Ok(Nil) = bag.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_readonly_delete_all_fails_test() {
+pub fn bag_readonly_delete_all_fails_test() -> Nil {
   let path = "test_bag_ro_del_all.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -285,12 +286,12 @@ pub fn bag_readonly_delete_all_fails_test() {
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(["v"]) = bag.lookup(rw, key: "k")
   let assert Ok(Nil) = bag.close(rw)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: read-only ─────────────────────────────────────────────
 
-pub fn dupbag_readonly_lookup_test() {
+pub fn dupbag_readonly_lookup_test() -> Nil {
   let path = "test_dupbag_ro_lookup.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -312,10 +313,10 @@ pub fn dupbag_readonly_lookup_test() {
   let assert Ok(values) = duplicate_bag.lookup(ro, key: "k")
   values |> expect.to_equal(["v", "v"])
   let assert Ok(Nil) = duplicate_bag.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_readonly_insert_fails_test() {
+pub fn dupbag_readonly_insert_fails_test() -> Nil {
   let path = "test_dupbag_ro_insert.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -335,10 +336,10 @@ pub fn dupbag_readonly_insert_fails_test() {
   let result = duplicate_bag.insert(ro, "k", "v")
   result |> expect.to_equal(Error(slate.AccessDenied))
   let assert Ok(Nil) = duplicate_bag.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_readonly_delete_all_fails_test() {
+pub fn dupbag_readonly_delete_all_fails_test() -> Nil {
   let path = "test_dupbag_ro_del_all.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -358,12 +359,12 @@ pub fn dupbag_readonly_delete_all_fails_test() {
     )
   duplicate_bag.delete_all(ro) |> expect.to_equal(Error(slate.AccessDenied))
   let _ = duplicate_bag.close(ro)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── ReadWrite mode works normally ───────────────────────────────────────
 
-pub fn set_readwrite_mode_test() {
+pub fn set_readwrite_mode_test() -> Nil {
   let path = "test_set_rw_mode.dets"
   let assert Ok(table) =
     set.open_with_access(
@@ -376,5 +377,5 @@ pub fn set_readwrite_mode_test() {
   let assert Ok(Nil) = set.insert(table, "key", "val")
   let assert Ok("val") = set.lookup(table, key: "key")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/bag_otp_test.gleam
+++ b/test/bag_otp_test.gleam
@@ -1,4 +1,5 @@
-/// Tests adapted from the Erlang/OTP dets_SUITE.erl test suite for bag tables.
+//// Tests adapted from the Erlang/OTP dets_SUITE.erl test suite for bag tables.
+
 import gleam/dynamic/decode
 import gleam/int
 import gleam/list
@@ -6,14 +7,14 @@ import gleam/string
 import slate
 import slate/bag
 import startest/expect
-import test_helpers.{cleanup, range, unsafe_decoder}
+import test_helpers
 
 // ── insert_new semantics for bags (OTP insert_new test) ─────────────────
 // In OTP: insert_new on a bag returns false if the *key* already exists,
 // even if the value is different. Bags in slate don't expose insert_new,
 // so we test that insert properly deduplicates.
 
-pub fn bag_insert_deduplicates_test() {
+pub fn bag_insert_deduplicates_test() -> Nil {
   let path = "test_bag_dedup.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -25,12 +26,12 @@ pub fn bag_insert_deduplicates_test() {
   let assert Ok(values) = bag.lookup(table, key: "color")
   values |> list.length |> expect.to_equal(1)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Multiple distinct values per key ────────────────────────────────────
 
-pub fn bag_many_distinct_values_test() {
+pub fn bag_many_distinct_values_test() -> Nil {
   let path = "test_bag_distinct.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -46,12 +47,12 @@ pub fn bag_many_distinct_values_test() {
   colors
   |> list.each(fn(c) { list.contains(values, c) |> expect.to_be_true() })
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Integer vs Float key distinction ────────────────────────────────────
 
-pub fn bag_int_key_test() {
+pub fn bag_int_key_test() -> Nil {
   let path = "test_bag_int_key.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -60,10 +61,10 @@ pub fn bag_int_key_test() {
   let assert Ok(vals) = bag.lookup(table, key: 1)
   vals |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_float_key_test() {
+pub fn bag_float_key_test() -> Nil {
   let path = "test_bag_float_key.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.float, value_decoder: decode.string)
@@ -72,12 +73,12 @@ pub fn bag_float_key_test() {
   let assert Ok(vals) = bag.lookup(table, key: 1.0)
   vals |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Unicode keys and values ─────────────────────────────────────────────
 
-pub fn bag_unicode_test() {
+pub fn bag_unicode_test() -> Nil {
   let path = "test_bag_unicode.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -86,12 +87,12 @@ pub fn bag_unicode_test() {
   let assert Ok(values) = bag.lookup(table, key: "タグ")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Large values ────────────────────────────────────────────────────────
 
-pub fn bag_large_values_test() {
+pub fn bag_large_values_test() -> Nil {
   let path = "test_bag_large_vals.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -102,12 +103,12 @@ pub fn bag_large_values_test() {
   let assert Ok(values) = bag.lookup(table, key: "key")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Delete key removes all values ───────────────────────────────────────
 
-pub fn bag_delete_key_removes_all_values_test() {
+pub fn bag_delete_key_removes_all_values_test() -> Nil {
   let path = "test_bag_del_all_vals.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -119,12 +120,12 @@ pub fn bag_delete_key_removes_all_values_test() {
   bag.size(table) |> expect.to_equal(Ok(0))
   bag.lookup(table, key: "k") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── delete_all then reuse ───────────────────────────────────────────────
 
-pub fn bag_delete_all_reuse_test() {
+pub fn bag_delete_all_reuse_test() -> Nil {
   let path = "test_bag_del_all_reuse.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -134,12 +135,12 @@ pub fn bag_delete_all_reuse_test() {
   let assert Ok(Nil) = bag.insert(table, "x", 42)
   bag.size(table) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Persistence with multiple values ────────────────────────────────────
 
-pub fn bag_persistence_multiple_values_test() {
+pub fn bag_persistence_multiple_values_test() -> Nil {
   let path = "test_bag_persist_multi.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -156,12 +157,12 @@ pub fn bag_persistence_multiple_values_test() {
   list.contains(values, "erlang") |> expect.to_be_true()
   list.contains(values, "beam") |> expect.to_be_true()
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Size counts each value separately ───────────────────────────────────
 
-pub fn bag_size_counts_objects_not_keys_test() {
+pub fn bag_size_counts_objects_not_keys_test() -> Nil {
   let path = "test_bag_size_objects.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -172,12 +173,12 @@ pub fn bag_size_counts_objects_not_keys_test() {
   // 4 objects total (3 for k1, 1 for k2)
   bag.size(table) |> expect.to_equal(Ok(4))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Fold over bag accumulates all entries ────────────────────────────────
 
-pub fn bag_fold_all_entries_test() {
+pub fn bag_fold_all_entries_test() -> Nil {
   let path = "test_bag_fold_all.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -188,12 +189,12 @@ pub fn bag_fold_all_entries_test() {
   let assert Ok(pairs) = bag.fold(table, [], fn(acc, k, v) { [#(k, v), ..acc] })
   pairs |> list.length |> expect.to_equal(4)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Boundary: negative integer keys ─────────────────────────────────────
 
-pub fn bag_negative_keys_test() {
+pub fn bag_negative_keys_test() -> Nil {
   let path = "test_bag_neg_keys.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -202,15 +203,19 @@ pub fn bag_negative_keys_test() {
   let assert Ok(values) = bag.lookup(table, key: -1)
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Tuple keys in bags ──────────────────────────────────────────────────
 
-pub fn bag_tuple_keys_test() {
+pub fn bag_tuple_keys_test() -> Nil {
   let path = "test_bag_tuple_keys.dets"
   let assert Ok(table) =
-    bag.open(path, key_decoder: unsafe_decoder(), value_decoder: decode.string)
+    bag.open(
+      path,
+      key_decoder: test_helpers.unsafe_decoder(),
+      value_decoder: decode.string,
+    )
   let assert Ok(Nil) = bag.insert(table, #("user", 1), "admin")
   let assert Ok(Nil) = bag.insert(table, #("user", 1), "editor")
   let assert Ok(Nil) = bag.insert(table, #("user", 2), "viewer")
@@ -219,14 +224,14 @@ pub fn bag_tuple_keys_test() {
   let assert Ok(vals_2) = bag.lookup(table, key: #("user", 2))
   vals_2 |> expect.to_equal(["viewer"])
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Many open/close cycles ──────────────────────────────────────────────
 
-pub fn bag_many_open_close_cycles_test() {
+pub fn bag_many_open_close_cycles_test() -> Nil {
   let path = "test_bag_many_cycles.dets"
-  range(1, 10)
+  test_helpers.range(1, 10)
   |> list.each(fn(i) {
     let assert Ok(table) =
       bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -240,12 +245,12 @@ pub fn bag_many_open_close_cycles_test() {
   // Bag keeps distinct values, so we get 10 values
   values |> list.length |> expect.to_equal(10)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── with_table error propagation ────────────────────────────────────────
 
-pub fn bag_with_table_error_propagation_test() {
+pub fn bag_with_table_error_propagation_test() -> Nil {
   let path = "test_bag_with_err.dets"
   let result =
     bag.with_table(
@@ -255,18 +260,18 @@ pub fn bag_with_table_error_propagation_test() {
       fun: fn(_table) { Error(slate.UnexpectedError("test error")) },
     )
   result |> expect.to_equal(Error(slate.UnexpectedError("test error")))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Large dataset with many keys ────────────────────────────────────────
 
-pub fn bag_large_many_keys_test() {
+pub fn bag_large_many_keys_test() -> Nil {
   let path = "test_bag_large_keys.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
   // 500 keys, 2 values each = 1000 objects
   let entries =
-    range(0, 499)
+    test_helpers.range(0, 499)
     |> list.flat_map(fn(i) {
       [#(int.to_string(i), i), #(int.to_string(i), i + 1000)]
     })
@@ -278,23 +283,23 @@ pub fn bag_large_many_keys_test() {
   let assert Ok(vals_last) = bag.lookup(table, key: "499")
   vals_last |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── member on empty bag ─────────────────────────────────────────────────
 
-pub fn bag_member_empty_test() {
+pub fn bag_member_empty_test() -> Nil {
   let path = "test_bag_member_empty.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   bag.member(table, key: "anything") |> expect.to_equal(Ok(False))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Sync then reopen ────────────────────────────────────────────────────
 
-pub fn bag_sync_then_reopen_test() {
+pub fn bag_sync_then_reopen_test() -> Nil {
   let path = "test_bag_sync_reopen.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -305,5 +310,5 @@ pub fn bag_sync_then_reopen_test() {
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(["synced"]) = bag.lookup(table2, key: "key")
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/bag_test.gleam
+++ b/test/bag_test.gleam
@@ -5,21 +5,21 @@ import gleam/string
 import slate
 import slate/bag
 import startest/expect
-import test_helpers.{cleanup, did_panic, is_table_open, range, unsafe_decoder}
+import test_helpers
 
 // ── Bag: Open / Close ───────────────────────────────────────────────────
 
-pub fn bag_open_close_test() {
+pub fn bag_open_close_test() -> Nil {
   let path = "test_bag_open_close.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Insert / Lookup ────────────────────────────────────────────────
 
-pub fn bag_insert_lookup_test() {
+pub fn bag_insert_lookup_test() -> Nil {
   let path = "test_bag_insert.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -28,10 +28,10 @@ pub fn bag_insert_lookup_test() {
   let assert Ok(values) = bag.lookup(table, key: "color")
   values |> list.sort(string.compare) |> expect.to_equal(["blue", "red"])
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_no_duplicates_test() {
+pub fn bag_no_duplicates_test() -> Nil {
   let path = "test_bag_no_dupes.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -41,21 +41,21 @@ pub fn bag_no_duplicates_test() {
   let assert Ok(values) = bag.lookup(table, key: "key")
   values |> list.length |> expect.to_equal(1)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_lookup_empty_test() {
+pub fn bag_lookup_empty_test() -> Nil {
   let path = "test_bag_lookup_empty.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   bag.lookup(table, key: "missing") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Member ─────────────────────────────────────────────────────────
 
-pub fn bag_member_test() {
+pub fn bag_member_test() -> Nil {
   let path = "test_bag_member.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -63,12 +63,12 @@ pub fn bag_member_test() {
   bag.member(table, key: "exists") |> expect.to_equal(Ok(True))
   bag.member(table, key: "nope") |> expect.to_equal(Ok(False))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Delete ─────────────────────────────────────────────────────────
 
-pub fn bag_delete_key_test() {
+pub fn bag_delete_key_test() -> Nil {
   let path = "test_bag_delete.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -77,10 +77,10 @@ pub fn bag_delete_key_test() {
   let assert Ok(Nil) = bag.delete_key(table, key: "key")
   bag.lookup(table, key: "key") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_delete_all_test() {
+pub fn bag_delete_all_test() -> Nil {
   let path = "test_bag_delete_all.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -89,12 +89,12 @@ pub fn bag_delete_all_test() {
   let assert Ok(Nil) = bag.delete_all(table)
   bag.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Size ───────────────────────────────────────────────────────────
 
-pub fn bag_size_test() {
+pub fn bag_size_test() -> Nil {
   let path = "test_bag_size.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -104,12 +104,12 @@ pub fn bag_size_test() {
   let assert Ok(Nil) = bag.insert(table, "b", 3)
   bag.size(table) |> expect.to_equal(Ok(3))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Fold ───────────────────────────────────────────────────────────
 
-pub fn bag_fold_test() {
+pub fn bag_fold_test() -> Nil {
   let path = "test_bag_fold.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -119,12 +119,12 @@ pub fn bag_fold_test() {
   let assert Ok(sum) = bag.fold(table, 0, fn(acc, _key, val) { acc + val })
   sum |> expect.to_equal(60)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Persistence ────────────────────────────────────────────────────
 
-pub fn bag_persistence_test() {
+pub fn bag_persistence_test() -> Nil {
   let path = "test_bag_persist.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -137,12 +137,12 @@ pub fn bag_persistence_test() {
   let assert Ok(values) = bag.lookup(table2, key: "key")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Info ───────────────────────────────────────────────────────────
 
-pub fn bag_info_test() {
+pub fn bag_info_test() -> Nil {
   let path = "test_bag_info.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -150,24 +150,28 @@ pub fn bag_info_test() {
   let assert Ok(info) = bag.info(table)
   info.object_count |> expect.to_equal(1)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Complex value types ────────────────────────────────────────────
 
-pub fn bag_tuple_values_test() {
+pub fn bag_tuple_values_test() -> Nil {
   let path = "test_bag_tuple_vals.dets"
   let assert Ok(table) =
-    bag.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    bag.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   let assert Ok(Nil) = bag.insert(table, "point", #(1, 2))
   let assert Ok(Nil) = bag.insert(table, "point", #(3, 4))
   let assert Ok(values) = bag.lookup(table, key: "point")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_list_values_test() {
+pub fn bag_list_values_test() -> Nil {
   let path = "test_bag_list_vals.dets"
   let assert Ok(table) =
     bag.open(
@@ -180,19 +184,19 @@ pub fn bag_list_values_test() {
   let assert Ok(values) = bag.lookup(table, key: "nums")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Large dataset ──────────────────────────────────────────────────
 
-pub fn bag_large_dataset_test() {
+pub fn bag_large_dataset_test() -> Nil {
   let path = "test_bag_large.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
   // Insert 100 keys with 10 values each = 1000 entries
-  range(0, 99)
+  test_helpers.range(0, 99)
   |> list.each(fn(key) {
-    range(0, 9)
+    test_helpers.range(0, 9)
     |> list.each(fn(val) {
       let assert Ok(Nil) = bag.insert(table, int.to_string(key), key * 10 + val)
       Nil
@@ -203,12 +207,12 @@ pub fn bag_large_dataset_test() {
   let assert Ok(vals) = bag.lookup(table, key: "0")
   vals |> list.length |> expect.to_equal(10)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Shared access ──────────────────────────────────────────────────
 
-pub fn bag_shared_access_test() {
+pub fn bag_shared_access_test() -> Nil {
   let path = "test_bag_shared.dets"
   let assert Ok(t1) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -220,31 +224,31 @@ pub fn bag_shared_access_test() {
   vals |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(t1)
   let assert Ok(Nil) = bag.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: Edge cases ─────────────────────────────────────────────────────
 
-pub fn bag_delete_nonexistent_key_test() {
+pub fn bag_delete_nonexistent_key_test() -> Nil {
   let path = "test_bag_del_missing.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = bag.delete_key(table, key: "nope")
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_fold_empty_test() {
+pub fn bag_fold_empty_test() -> Nil {
   let path = "test_bag_fold_empty.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let assert Ok(result) = bag.fold(table, 0, fn(acc, _k, _v) { acc + 1 })
   result |> expect.to_equal(0)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_insert_list_test() {
+pub fn bag_insert_list_test() -> Nil {
   let path = "test_bag_insert_list.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -253,10 +257,10 @@ pub fn bag_insert_list_test() {
   let assert Ok(vals) = bag.lookup(table, key: "k")
   vals |> list.sort(string.compare) |> expect.to_equal(["a", "b", "c"])
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_with_table_test() {
+pub fn bag_with_table_test() -> Nil {
   let path = "test_bag_with_table.dets"
   let assert Ok(Nil) =
     bag.with_table(
@@ -269,10 +273,10 @@ pub fn bag_with_table_test() {
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(["val"]) = bag.lookup(table, key: "key")
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_with_table_close_error_propagates_test() {
+pub fn bag_with_table_close_error_propagates_test() -> Nil {
   let path = "test_bag_with_close_err.dets"
   let result =
     bag.with_table(
@@ -289,12 +293,12 @@ pub fn bag_with_table_close_error_propagates_test() {
     Ok(_) -> False
   }
   close_error_propagated |> expect.to_be_true()
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_with_table_panic_still_closes_test() {
+pub fn bag_with_table_panic_still_closes_test() -> Nil {
   let path = "test_bag_with_panic.dets"
-  did_panic(fn() {
+  test_helpers.did_panic(fn() {
     let _ =
       bag.with_table(
         path,
@@ -308,15 +312,15 @@ pub fn bag_with_table_panic_still_closes_test() {
     Nil
   })
   |> expect.to_be_true()
-  is_table_open(path) |> expect.to_equal(False)
+  test_helpers.is_table_open(path) |> expect.to_equal(False)
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(["val"]) = bag.lookup(table, key: "key")
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_with_table_open_error_test() {
+pub fn bag_with_table_open_error_test() -> Nil {
   let path = "missing_bag_with_table_dir/test_bag_with_table_open_error.dets"
   bag.with_table(
     path,
@@ -325,10 +329,10 @@ pub fn bag_with_table_open_error_test() {
     fun: fn(_table) { Ok(Nil) },
   )
   |> expect.to_equal(Error(slate.FileNotFound))
-  is_table_open(path) |> expect.to_equal(False)
+  test_helpers.is_table_open(path) |> expect.to_equal(False)
 }
 
-pub fn bag_repair_policies_test() {
+pub fn bag_repair_policies_test() -> Nil {
   let path = "test_bag_repair.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -344,19 +348,19 @@ pub fn bag_repair_policies_test() {
     )
   let assert Ok(["val"]) = bag.lookup(table2, key: "key")
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_many_values_per_key_test() {
+pub fn bag_many_values_per_key_test() -> Nil {
   let path = "test_bag_many_vals.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let entries =
-    range(0, 99)
+    test_helpers.range(0, 99)
     |> list.map(fn(i) { #("single_key", i) })
   let assert Ok(Nil) = bag.insert_list(table, entries)
   let assert Ok(vals) = bag.lookup(table, key: "single_key")
   vals |> list.length |> expect.to_equal(100)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/corruption_test.gleam
+++ b/test/corruption_test.gleam
@@ -1,26 +1,31 @@
-/// Corruption and repair stress tests.
-/// Adapted from OTP dets_SUITE repair/1 and open_file/1 tests.
-///
-/// These tests verify that DETS handles file corruption gracefully:
-/// - Truncated files trigger repair
-/// - Corrupted bytes are detected
-/// - NoRepair mode rejects damaged files
-/// - AutoRepair mode fixes damaged files
+//// Corruption and repair stress tests.
+//// Adapted from OTP dets_SUITE repair/1 and open_file/1 tests.
+////
+//// These tests verify that DETS handles file corruption gracefully:
+//// - Truncated files trigger repair
+//// - Corrupted bytes are detected
+//// - NoRepair mode rejects damaged files
+//// - AutoRepair mode fixes damaged files
+
 import gleam/dynamic/decode
+import gleam/list
 import slate
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, range}
+import test_helpers
 
 // ── Truncated file with AutoRepair recovers ─────────────────────────────
 // OTP: truncated file triggers repair, data may be partially recovered.
 
-pub fn truncated_file_auto_repair_test() {
+pub fn truncated_file_auto_repair_test() -> Nil {
   let path = "test_truncated_auto.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
-    set.insert_list(table, range(0, 99) |> list.map(fn(i) { #(i, i * 2) }))
+    set.insert_list(
+      table,
+      test_helpers.range(0, 99) |> list.map(fn(i) { #(i, i * 2) }),
+    )
   let assert Ok(Nil) = set.close(table)
   // Get file size and truncate to half
   let assert Ok(file_size) = get_file_size(path)
@@ -46,13 +51,13 @@ pub fn truncated_file_auto_repair_test() {
       Nil
     }
   }
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── NoRepair rejects damaged file ───────────────────────────────────────
 // OTP: {error,{needs_repair, Fname}} when repair=false
 
-pub fn no_repair_rejects_corrupted_file_test() {
+pub fn no_repair_rejects_corrupted_file_test() -> Nil {
   let path = "test_no_repair_reject.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -69,18 +74,21 @@ pub fn no_repair_rejects_corrupted_file_test() {
       value_decoder: decode.string,
     )
   result |> expect.to_equal(Error(slate.NeedsRepair))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── ForceRepair on corrupted file ───────────────────────────────────────
 // OTP: force repair rebuilds from file data
 
-pub fn force_repair_on_corrupted_file_test() {
+pub fn force_repair_on_corrupted_file_test() -> Nil {
   let path = "test_force_repair_corrupt.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
-    set.insert_list(table, range(0, 49) |> list.map(fn(i) { #(i, i) }))
+    set.insert_list(
+      table,
+      test_helpers.range(0, 49) |> list.map(fn(i) { #(i, i) }),
+    )
   let assert Ok(Nil) = set.close(table)
   // Corrupt a byte in the data area (far past the header)
   let assert Ok(Nil) = corrupt_byte(path, 500)
@@ -106,25 +114,25 @@ pub fn force_repair_on_corrupted_file_test() {
       Nil
     }
   }
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Non-DETS file fails to open ─────────────────────────────────────────
 // OTP: {error,{not_a_dets_file,Fname}}
 
-pub fn open_non_dets_file_test() {
+pub fn open_non_dets_file_test() -> Nil {
   let path = "test_not_dets.dets"
   // Write random garbage that isn't a DETS file
   let assert Ok(Nil) = write_garbage(path)
   let result =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   result |> expect.to_equal(Error(slate.NotADetsFile))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Severely truncated file (header only) ───────────────────────────────
 
-pub fn truncated_to_header_test() {
+pub fn truncated_to_header_test() -> Nil {
   let path = "test_truncated_header.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -142,12 +150,12 @@ pub fn truncated_to_header_test() {
       Nil
     }
   }
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Empty file (0 bytes) ────────────────────────────────────────────────
 
-pub fn empty_file_test() {
+pub fn empty_file_test() -> Nil {
   let path = "test_empty_file.dets"
   let assert Ok(Nil) = truncate_file_create(path)
   let result =
@@ -160,12 +168,10 @@ pub fn empty_file_test() {
       Nil
     }
   }
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── FFI helpers ─────────────────────────────────────────────────────────
-
-import gleam/list
 
 @external(erlang, "corruption_test_ffi", "truncate_file")
 fn truncate_file(path: String, position: Int) -> Result(Nil, Nil)

--- a/test/delete_object_test.gleam
+++ b/test/delete_object_test.gleam
@@ -1,5 +1,6 @@
-/// Tests for the delete_object API across all table types.
-/// Adapted from OTP dets_SUITE del_obj_test and related tests.
+//// Tests for the delete_object API across all table types.
+//// Adapted from OTP dets_SUITE del_obj_test and related tests.
+
 import gleam/dynamic/decode
 import gleam/list
 import gleam/string
@@ -7,11 +8,11 @@ import slate/bag
 import slate/duplicate_bag
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, range}
+import test_helpers
 
 // ── Set: delete_object ──────────────────────────────────────────────────
 
-pub fn set_delete_object_test() {
+pub fn set_delete_object_test() -> Nil {
   let path = "test_set_del_obj.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -19,10 +20,10 @@ pub fn set_delete_object_test() {
   let assert Ok(Nil) = set.delete_object(table, "key", "val")
   set.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_delete_object_wrong_value_test() {
+pub fn set_delete_object_wrong_value_test() -> Nil {
   let path = "test_set_del_obj_wrong.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -32,22 +33,22 @@ pub fn set_delete_object_wrong_value_test() {
   set.size(table) |> expect.to_equal(Ok(1))
   let assert Ok("correct") = set.lookup(table, key: "key")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_delete_object_nonexistent_test() {
+pub fn set_delete_object_nonexistent_test() -> Nil {
   let path = "test_set_del_obj_none.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   // Deleting from empty table should succeed silently
   let assert Ok(Nil) = set.delete_object(table, "key", "val")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: delete_object ──────────────────────────────────────────────────
 
-pub fn bag_delete_object_removes_one_value_test() {
+pub fn bag_delete_object_removes_one_value_test() -> Nil {
   let path = "test_bag_del_obj.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -62,10 +63,10 @@ pub fn bag_delete_object_removes_one_value_test() {
   list.contains(values, "blue") |> expect.to_be_true()
   list.contains(values, "green") |> expect.to_be_true()
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_delete_object_all_values_one_by_one_test() {
+pub fn bag_delete_object_all_values_one_by_one_test() -> Nil {
   let path = "test_bag_del_obj_all.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -78,10 +79,10 @@ pub fn bag_delete_object_all_values_one_by_one_test() {
   bag.size(table) |> expect.to_equal(Ok(0))
   bag.lookup(table, key: "k") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_delete_object_wrong_value_test() {
+pub fn bag_delete_object_wrong_value_test() -> Nil {
   let path = "test_bag_del_obj_wrong.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -91,10 +92,10 @@ pub fn bag_delete_object_wrong_value_test() {
   let assert Ok(Nil) = bag.delete_object(table, "k", "z")
   bag.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_delete_object_preserves_other_keys_test() {
+pub fn bag_delete_object_preserves_other_keys_test() -> Nil {
   let path = "test_bag_del_obj_other.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -108,10 +109,10 @@ pub fn bag_delete_object_preserves_other_keys_test() {
   let assert Ok(vals2) = bag.lookup(table, key: "k2")
   vals2 |> expect.to_equal(["x"])
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_delete_object_persistence_test() {
+pub fn bag_delete_object_persistence_test() -> Nil {
   let path = "test_bag_del_obj_persist.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -124,34 +125,34 @@ pub fn bag_delete_object_persistence_test() {
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(["keep"]) = bag.lookup(table2, key: "k")
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_delete_object_large_test() {
+pub fn bag_delete_object_large_test() -> Nil {
   let path = "test_bag_del_obj_large.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   // Insert 100 distinct values for one key
-  range(0, 99)
+  test_helpers.range(0, 99)
   |> list.each(fn(i) {
     let assert Ok(Nil) = bag.insert(table, "key", string.inspect(i))
     Nil
   })
   bag.size(table) |> expect.to_equal(Ok(100))
   // Delete half
-  range(0, 49)
+  test_helpers.range(0, 49)
   |> list.each(fn(i) {
     let assert Ok(Nil) = bag.delete_object(table, "key", string.inspect(i))
     Nil
   })
   bag.size(table) |> expect.to_equal(Ok(50))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: delete_object ─────────────────────────────────────────
 
-pub fn dupbag_delete_object_removes_all_copies_test() {
+pub fn dupbag_delete_object_removes_all_copies_test() -> Nil {
   let path = "test_dupbag_del_obj.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -168,10 +169,10 @@ pub fn dupbag_delete_object_removes_all_copies_test() {
   values |> expect.to_equal(["b"])
   duplicate_bag.size(table) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_delete_object_preserves_other_duplicates_test() {
+pub fn dupbag_delete_object_preserves_other_duplicates_test() -> Nil {
   let path = "test_dupbag_del_obj_other.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -189,10 +190,10 @@ pub fn dupbag_delete_object_preserves_other_duplicates_test() {
   values |> expect.to_equal(["b", "b"])
   duplicate_bag.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_delete_object_wrong_value_test() {
+pub fn dupbag_delete_object_wrong_value_test() -> Nil {
   let path = "test_dupbag_del_obj_wrong.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -205,10 +206,10 @@ pub fn dupbag_delete_object_wrong_value_test() {
   let assert Ok(Nil) = duplicate_bag.delete_object(table, "k", "z")
   duplicate_bag.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_delete_object_persistence_test() {
+pub fn dupbag_delete_object_persistence_test() -> Nil {
   let path = "test_dupbag_del_obj_persist.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -230,10 +231,10 @@ pub fn dupbag_delete_object_persistence_test() {
   let assert Ok(values) = duplicate_bag.lookup(table2, key: "k")
   values |> expect.to_equal(["keep", "keep"])
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_delete_object_empty_table_test() {
+pub fn dupbag_delete_object_empty_table_test() -> Nil {
   let path = "test_dupbag_del_obj_empty.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -244,10 +245,10 @@ pub fn dupbag_delete_object_empty_table_test() {
   let assert Ok(Nil) = duplicate_bag.delete_object(table, "k", "v")
   duplicate_bag.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_delete_object_preserves_other_keys_test() {
+pub fn dupbag_delete_object_preserves_other_keys_test() -> Nil {
   let path = "test_dupbag_del_obj_okeys.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -263,5 +264,5 @@ pub fn dupbag_delete_object_preserves_other_keys_test() {
   let assert Ok(vals) = duplicate_bag.lookup(table, key: "k2")
   vals |> expect.to_equal(["b"])
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/duplicate_bag_otp_test.gleam
+++ b/test/duplicate_bag_otp_test.gleam
@@ -1,4 +1,5 @@
-/// Tests adapted from the Erlang/OTP dets_SUITE.erl test suite for duplicate_bag.
+//// Tests adapted from the Erlang/OTP dets_SUITE.erl test suite for duplicate_bag.
+
 import gleam/dynamic/decode
 import gleam/int
 import gleam/list
@@ -6,11 +7,11 @@ import gleam/string
 import slate
 import slate/duplicate_bag
 import startest/expect
-import test_helpers.{cleanup, range, unsafe_decoder}
+import test_helpers
 
 // ── Duplicates are fully preserved (OTP core duplicate_bag test) ────────
 
-pub fn dupbag_exact_duplicate_count_test() {
+pub fn dupbag_exact_duplicate_count_test() -> Nil {
   let path = "test_dupbag_exact_count.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -19,7 +20,7 @@ pub fn dupbag_exact_duplicate_count_test() {
       value_decoder: decode.string,
     )
   // Insert the exact same pair 5 times
-  range(1, 5)
+  test_helpers.range(1, 5)
   |> list.each(fn(_) {
     let assert Ok(Nil) = duplicate_bag.insert(table, "k", "same")
     Nil
@@ -31,7 +32,7 @@ pub fn dupbag_exact_duplicate_count_test() {
   |> list.all(fn(v) { v == "same" })
   |> expect.to_be_true()
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── OTP-8070: insert_new with duplicate_bag ──────────────────────────────
@@ -39,7 +40,7 @@ pub fn dupbag_exact_duplicate_count_test() {
 // insert_new, which is correct. We verify the fundamental behavior:
 // duplicates are stored, not deduplicated.
 
-pub fn dupbag_mixed_duplicates_and_distinct_test() {
+pub fn dupbag_mixed_duplicates_and_distinct_test() -> Nil {
   let path = "test_dupbag_mixed.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -71,12 +72,12 @@ pub fn dupbag_mixed_duplicates_and_distinct_test() {
   |> list.length
   |> expect.to_equal(1)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Integer vs Float key distinction ────────────────────────────────────
 
-pub fn dupbag_int_key_test() {
+pub fn dupbag_int_key_test() -> Nil {
   let path = "test_dupbag_int_key.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -89,10 +90,10 @@ pub fn dupbag_int_key_test() {
   let assert Ok(vals) = duplicate_bag.lookup(table, key: 1)
   vals |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_float_key_test() {
+pub fn dupbag_float_key_test() -> Nil {
   let path = "test_dupbag_float_key.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -105,12 +106,12 @@ pub fn dupbag_float_key_test() {
   let assert Ok(vals) = duplicate_bag.lookup(table, key: 1.0)
   vals |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Unicode ─────────────────────────────────────────────────────────────
 
-pub fn dupbag_unicode_test() {
+pub fn dupbag_unicode_test() -> Nil {
   let path = "test_dupbag_unicode.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -124,12 +125,12 @@ pub fn dupbag_unicode_test() {
   let assert Ok(values) = duplicate_bag.lookup(table, key: "🔑")
   values |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Large values ────────────────────────────────────────────────────────
 
-pub fn dupbag_large_values_test() {
+pub fn dupbag_large_values_test() -> Nil {
   let path = "test_dupbag_large_vals.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -148,12 +149,12 @@ pub fn dupbag_large_values_test() {
   }
   string.length(first) |> expect.to_equal(5000)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Persistence preserves duplicate count ───────────────────────────────
 
-pub fn dupbag_persistence_preserves_duplicates_test() {
+pub fn dupbag_persistence_preserves_duplicates_test() -> Nil {
   let path = "test_dupbag_persist_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -174,12 +175,12 @@ pub fn dupbag_persistence_preserves_duplicates_test() {
   let assert Ok(values) = duplicate_bag.lookup(table2, key: "k")
   values |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── delete_key removes all duplicates ───────────────────────────────────
 
-pub fn dupbag_delete_key_all_duplicates_test() {
+pub fn dupbag_delete_key_all_duplicates_test() -> Nil {
   let path = "test_dupbag_del_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -187,19 +188,19 @@ pub fn dupbag_delete_key_all_duplicates_test() {
       key_decoder: decode.string,
       value_decoder: decode.string,
     )
-  let entries = range(1, 20) |> list.map(fn(_) { #("k", "same") })
+  let entries = test_helpers.range(1, 20) |> list.map(fn(_) { #("k", "same") })
   let assert Ok(Nil) = duplicate_bag.insert_list(table, entries)
   duplicate_bag.size(table) |> expect.to_equal(Ok(20))
   let assert Ok(Nil) = duplicate_bag.delete_key(table, key: "k")
   duplicate_bag.size(table) |> expect.to_equal(Ok(0))
   duplicate_bag.lookup(table, key: "k") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Size counts every duplicate ─────────────────────────────────────────
 
-pub fn dupbag_size_counts_all_duplicates_test() {
+pub fn dupbag_size_counts_all_duplicates_test() -> Nil {
   let path = "test_dupbag_size_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -215,12 +216,12 @@ pub fn dupbag_size_counts_all_duplicates_test() {
   // 5 total objects: a→1, a→1, a→2, b→1, b→1
   duplicate_bag.size(table) |> expect.to_equal(Ok(5))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Fold counts duplicates correctly ────────────────────────────────────
 
-pub fn dupbag_fold_counts_duplicates_test() {
+pub fn dupbag_fold_counts_duplicates_test() -> Nil {
   let path = "test_dupbag_fold_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -234,12 +235,12 @@ pub fn dupbag_fold_counts_duplicates_test() {
   let assert Ok(sum) = duplicate_bag.fold(table, 0, fn(acc, _k, v) { acc + v })
   sum |> expect.to_equal(15)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── to_list includes all duplicates ─────────────────────────────────────
 
-pub fn dupbag_to_list_includes_duplicates_test() {
+pub fn dupbag_to_list_includes_duplicates_test() -> Nil {
   let path = "test_dupbag_to_list_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -257,12 +258,12 @@ pub fn dupbag_to_list_includes_duplicates_test() {
   |> list.length
   |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Negative integer keys ───────────────────────────────────────────────
 
-pub fn dupbag_negative_keys_test() {
+pub fn dupbag_negative_keys_test() -> Nil {
   let path = "test_dupbag_neg_keys.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -275,17 +276,17 @@ pub fn dupbag_negative_keys_test() {
   let assert Ok(values) = duplicate_bag.lookup(table, key: -42)
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Tuple keys ──────────────────────────────────────────────────────────
 
-pub fn dupbag_tuple_keys_test() {
+pub fn dupbag_tuple_keys_test() -> Nil {
   let path = "test_dupbag_tuple_keys.dets"
   let assert Ok(table) =
     duplicate_bag.open(
       path,
-      key_decoder: unsafe_decoder(),
+      key_decoder: test_helpers.unsafe_decoder(),
       value_decoder: decode.int,
     )
   let assert Ok(Nil) = duplicate_bag.insert(table, #("event", "click"), 1)
@@ -294,14 +295,14 @@ pub fn dupbag_tuple_keys_test() {
   let assert Ok(vals) = duplicate_bag.lookup(table, key: #("event", "click"))
   vals |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Many open/close cycles ──────────────────────────────────────────────
 
-pub fn dupbag_many_open_close_cycles_test() {
+pub fn dupbag_many_open_close_cycles_test() -> Nil {
   let path = "test_dupbag_many_cycles.dets"
-  range(1, 10)
+  test_helpers.range(1, 10)
   |> list.each(fn(i) {
     let assert Ok(table) =
       duplicate_bag.open(
@@ -323,12 +324,12 @@ pub fn dupbag_many_open_close_cycles_test() {
   // Duplicate bag stores all, so 10 entries
   values |> list.length |> expect.to_equal(10)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── delete_all persists ─────────────────────────────────────────────────
 
-pub fn dupbag_delete_all_persists_test() {
+pub fn dupbag_delete_all_persists_test() -> Nil {
   let path = "test_dupbag_del_all_persist.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -348,12 +349,12 @@ pub fn dupbag_delete_all_persists_test() {
     )
   duplicate_bag.size(table2) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Large dataset with duplicates ───────────────────────────────────────
 
-pub fn dupbag_large_with_heavy_duplicates_test() {
+pub fn dupbag_large_with_heavy_duplicates_test() -> Nil {
   let path = "test_dupbag_heavy_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -363,9 +364,10 @@ pub fn dupbag_large_with_heavy_duplicates_test() {
     )
   // 50 keys × 20 duplicates each = 1000 objects
   let entries =
-    range(0, 49)
+    test_helpers.range(0, 49)
     |> list.flat_map(fn(key) {
-      range(1, 20) |> list.map(fn(_) { #(int.to_string(key), key) })
+      test_helpers.range(1, 20)
+      |> list.map(fn(_) { #(int.to_string(key), key) })
     })
   let assert Ok(Nil) = duplicate_bag.insert_list(table, entries)
   duplicate_bag.size(table) |> expect.to_equal(Ok(1000))
@@ -374,12 +376,12 @@ pub fn dupbag_large_with_heavy_duplicates_test() {
   vals |> list.length |> expect.to_equal(20)
   vals |> list.all(fn(v) { v == 0 }) |> expect.to_be_true()
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── with_table error propagation ────────────────────────────────────────
 
-pub fn dupbag_with_table_error_propagation_test() {
+pub fn dupbag_with_table_error_propagation_test() -> Nil {
   let path = "test_dupbag_with_err.dets"
   let result =
     duplicate_bag.with_table(
@@ -389,12 +391,12 @@ pub fn dupbag_with_table_error_propagation_test() {
       fun: fn(_table) { Error(slate.UnexpectedError("test error")) },
     )
   result |> expect.to_equal(Error(slate.UnexpectedError("test error")))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Sync then reopen ────────────────────────────────────────────────────
 
-pub fn dupbag_sync_then_reopen_test() {
+pub fn dupbag_sync_then_reopen_test() -> Nil {
   let path = "test_dupbag_sync_reopen.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -415,12 +417,12 @@ pub fn dupbag_sync_then_reopen_test() {
   let assert Ok(values) = duplicate_bag.lookup(table2, key: "key")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bool values ─────────────────────────────────────────────────────────
 
-pub fn dupbag_bool_values_test() {
+pub fn dupbag_bool_values_test() -> Nil {
   let path = "test_dupbag_bool_vals.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -438,5 +440,5 @@ pub fn dupbag_bool_values_test() {
   |> list.length
   |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/duplicate_bag_test.gleam
+++ b/test/duplicate_bag_test.gleam
@@ -4,11 +4,11 @@ import gleam/list
 import slate
 import slate/duplicate_bag
 import startest/expect
-import test_helpers.{cleanup, did_panic, is_table_open, range}
+import test_helpers
 
 // ── DuplicateBag: Open / Close ──────────────────────────────────────────
 
-pub fn duplicate_bag_open_close_test() {
+pub fn duplicate_bag_open_close_test() -> Nil {
   let path = "test_dupbag_open_close.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -17,12 +17,12 @@ pub fn duplicate_bag_open_close_test() {
       value_decoder: decode.string,
     )
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Insert / Lookup ───────────────────────────────────────
 
-pub fn duplicate_bag_allows_duplicates_test() {
+pub fn duplicate_bag_allows_duplicates_test() -> Nil {
   let path = "test_dupbag_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -35,10 +35,10 @@ pub fn duplicate_bag_allows_duplicates_test() {
   let assert Ok(values) = duplicate_bag.lookup(table, key: "key")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_multiple_values_test() {
+pub fn duplicate_bag_multiple_values_test() -> Nil {
   let path = "test_dupbag_multi.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -52,10 +52,10 @@ pub fn duplicate_bag_multiple_values_test() {
   let assert Ok(values) = duplicate_bag.lookup(table, key: "key")
   values |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_lookup_empty_test() {
+pub fn duplicate_bag_lookup_empty_test() -> Nil {
   let path = "test_dupbag_empty.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -65,12 +65,12 @@ pub fn duplicate_bag_lookup_empty_test() {
     )
   duplicate_bag.lookup(table, key: "missing") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Size ──────────────────────────────────────────────────
 
-pub fn duplicate_bag_size_test() {
+pub fn duplicate_bag_size_test() -> Nil {
   let path = "test_dupbag_size.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -83,12 +83,12 @@ pub fn duplicate_bag_size_test() {
   let assert Ok(Nil) = duplicate_bag.insert(table, "b", 2)
   duplicate_bag.size(table) |> expect.to_equal(Ok(3))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Delete ────────────────────────────────────────────────
 
-pub fn duplicate_bag_delete_key_test() {
+pub fn duplicate_bag_delete_key_test() -> Nil {
   let path = "test_dupbag_delete.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -101,12 +101,12 @@ pub fn duplicate_bag_delete_key_test() {
   let assert Ok(Nil) = duplicate_bag.delete_key(table, key: "key")
   duplicate_bag.lookup(table, key: "key") |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Persistence ───────────────────────────────────────────
 
-pub fn duplicate_bag_persistence_test() {
+pub fn duplicate_bag_persistence_test() -> Nil {
   let path = "test_dupbag_persist.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -127,12 +127,12 @@ pub fn duplicate_bag_persistence_test() {
   let assert Ok(values) = duplicate_bag.lookup(table2, key: "k")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Info ──────────────────────────────────────────────────
 
-pub fn duplicate_bag_info_test() {
+pub fn duplicate_bag_info_test() -> Nil {
   let path = "test_dupbag_info.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -144,12 +144,12 @@ pub fn duplicate_bag_info_test() {
   let assert Ok(info) = duplicate_bag.info(table)
   info.object_count |> expect.to_equal(1)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Large duplicates ──────────────────────────────────────
 
-pub fn duplicate_bag_many_duplicates_test() {
+pub fn duplicate_bag_many_duplicates_test() -> Nil {
   let path = "test_dupbag_many_dupes.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -157,18 +157,19 @@ pub fn duplicate_bag_many_duplicates_test() {
       key_decoder: decode.string,
       value_decoder: decode.string,
     )
-  let entries = range(0, 49) |> list.map(fn(_i) { #("key", "same_value") })
+  let entries =
+    test_helpers.range(0, 49) |> list.map(fn(_i) { #("key", "same_value") })
   let assert Ok(Nil) = duplicate_bag.insert_list(table, entries)
   let assert Ok(vals) = duplicate_bag.lookup(table, key: "key")
   vals |> list.length |> expect.to_equal(50)
   duplicate_bag.size(table) |> expect.to_equal(Ok(50))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Shared access ─────────────────────────────────────────
 
-pub fn duplicate_bag_shared_access_test() {
+pub fn duplicate_bag_shared_access_test() -> Nil {
   let path = "test_dupbag_shared.dets"
   let assert Ok(t1) =
     duplicate_bag.open(
@@ -188,12 +189,12 @@ pub fn duplicate_bag_shared_access_test() {
   vals |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(t1)
   let assert Ok(Nil) = duplicate_bag.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: Edge cases ────────────────────────────────────────────
 
-pub fn duplicate_bag_delete_nonexistent_test() {
+pub fn duplicate_bag_delete_nonexistent_test() -> Nil {
   let path = "test_dupbag_del_missing.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -203,10 +204,10 @@ pub fn duplicate_bag_delete_nonexistent_test() {
     )
   let assert Ok(Nil) = duplicate_bag.delete_key(table, key: "nope")
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_fold_test() {
+pub fn duplicate_bag_fold_test() -> Nil {
   let path = "test_dupbag_fold.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -220,10 +221,10 @@ pub fn duplicate_bag_fold_test() {
   let assert Ok(sum) = duplicate_bag.fold(table, 0, fn(acc, _k, v) { acc + v })
   sum |> expect.to_equal(40)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_to_list_test() {
+pub fn duplicate_bag_to_list_test() -> Nil {
   let path = "test_dupbag_to_list.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -237,10 +238,10 @@ pub fn duplicate_bag_to_list_test() {
   let assert Ok(entries) = duplicate_bag.to_list(table)
   entries |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_delete_all_test() {
+pub fn duplicate_bag_delete_all_test() -> Nil {
   let path = "test_dupbag_del_all.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -254,10 +255,10 @@ pub fn duplicate_bag_delete_all_test() {
   let assert Ok(Nil) = duplicate_bag.delete_all(table)
   duplicate_bag.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_with_table_test() {
+pub fn duplicate_bag_with_table_test() -> Nil {
   let path = "test_dupbag_with_table.dets"
   let assert Ok(Nil) =
     duplicate_bag.with_table(
@@ -274,10 +275,10 @@ pub fn duplicate_bag_with_table_test() {
     )
   let assert Ok(["val"]) = duplicate_bag.lookup(table, key: "key")
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_with_table_close_error_propagates_test() {
+pub fn duplicate_bag_with_table_close_error_propagates_test() -> Nil {
   let path = "test_dupbag_with_close_err.dets"
   let result =
     duplicate_bag.with_table(
@@ -294,12 +295,12 @@ pub fn duplicate_bag_with_table_close_error_propagates_test() {
     Ok(_) -> False
   }
   close_error_propagated |> expect.to_be_true()
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_with_table_panic_still_closes_test() {
+pub fn duplicate_bag_with_table_panic_still_closes_test() -> Nil {
   let path = "test_dupbag_with_panic.dets"
-  did_panic(fn() {
+  test_helpers.did_panic(fn() {
     let _ =
       duplicate_bag.with_table(
         path,
@@ -313,7 +314,7 @@ pub fn duplicate_bag_with_table_panic_still_closes_test() {
     Nil
   })
   |> expect.to_be_true()
-  is_table_open(path) |> expect.to_equal(False)
+  test_helpers.is_table_open(path) |> expect.to_equal(False)
   let assert Ok(table) =
     duplicate_bag.open(
       path,
@@ -322,10 +323,10 @@ pub fn duplicate_bag_with_table_panic_still_closes_test() {
     )
   let assert Ok(["val"]) = duplicate_bag.lookup(table, key: "key")
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_with_table_open_error_test() {
+pub fn duplicate_bag_with_table_open_error_test() -> Nil {
   let path =
     "missing_dupbag_with_table_dir/test_dupbag_with_table_open_error.dets"
   duplicate_bag.with_table(
@@ -335,10 +336,10 @@ pub fn duplicate_bag_with_table_open_error_test() {
     fun: fn(_table) { Ok(Nil) },
   )
   |> expect.to_equal(Error(slate.FileNotFound))
-  is_table_open(path) |> expect.to_equal(False)
+  test_helpers.is_table_open(path) |> expect.to_equal(False)
 }
 
-pub fn duplicate_bag_repair_policies_test() {
+pub fn duplicate_bag_repair_policies_test() -> Nil {
   let path = "test_dupbag_repair.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -357,10 +358,10 @@ pub fn duplicate_bag_repair_policies_test() {
     )
   let assert Ok(["val"]) = duplicate_bag.lookup(table2, key: "key")
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_insert_list_test() {
+pub fn duplicate_bag_insert_list_test() -> Nil {
   let path = "test_dupbag_insert_list.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -377,10 +378,10 @@ pub fn duplicate_bag_insert_list_test() {
   let assert Ok(vals) = duplicate_bag.lookup(table, key: "k")
   vals |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_large_dataset_test() {
+pub fn duplicate_bag_large_dataset_test() -> Nil {
   let path = "test_dupbag_large.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -389,7 +390,7 @@ pub fn duplicate_bag_large_dataset_test() {
       value_decoder: decode.int,
     )
   let entries =
-    range(0, 999)
+    test_helpers.range(0, 999)
     |> list.map(fn(i) { #(int.to_string(i / 10), i) })
   let assert Ok(Nil) = duplicate_bag.insert_list(table, entries)
   duplicate_bag.size(table) |> expect.to_equal(Ok(1000))
@@ -397,10 +398,10 @@ pub fn duplicate_bag_large_dataset_test() {
   let assert Ok(vals) = duplicate_bag.lookup(table, key: "0")
   vals |> list.length |> expect.to_equal(10)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_member_test() {
+pub fn duplicate_bag_member_test() -> Nil {
   let path = "test_dupbag_member.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -412,5 +413,5 @@ pub fn duplicate_bag_member_test() {
   duplicate_bag.member(table, key: "exists") |> expect.to_equal(Ok(True))
   duplicate_bag.member(table, key: "nope") |> expect.to_equal(Ok(False))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/error_handling_test.gleam
+++ b/test/error_handling_test.gleam
@@ -1,5 +1,6 @@
-/// Tests for error handling edge cases.
-/// Adapted from OTP dets_SUITE badarg, repair, and access tests.
+//// Tests for error handling edge cases.
+//// Adapted from OTP dets_SUITE badarg, repair, and access tests.
+
 import gleam/dynamic/decode
 import gleam/int
 import gleam/list
@@ -8,9 +9,9 @@ import slate/bag
 import slate/duplicate_bag
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, range}
+import test_helpers
 
-fn expect_type_mismatch_open(result: Result(a, slate.DetsError)) {
+fn expect_type_mismatch_open(result: Result(a, slate.DetsError)) -> Nil {
   case result {
     Error(slate.TypeMismatch) -> Nil
     Error(slate.UnexpectedError(_)) -> Nil
@@ -21,7 +22,7 @@ fn expect_type_mismatch_open(result: Result(a, slate.DetsError)) {
 // ── Type mismatch: open set file as bag ─────────────────────────────────
 // OTP: {error,{type_mismatch,Fname}}
 
-pub fn type_mismatch_set_as_bag_test() {
+pub fn type_mismatch_set_as_bag_test() -> Nil {
   let path = "test_type_mismatch_sb.dets"
   // Create as set
   let assert Ok(table) =
@@ -32,10 +33,10 @@ pub fn type_mismatch_set_as_bag_test() {
   let result =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   expect_type_mismatch_open(result)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn type_mismatch_set_as_dupbag_test() {
+pub fn type_mismatch_set_as_dupbag_test() -> Nil {
   let path = "test_type_mismatch_sd.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -48,10 +49,10 @@ pub fn type_mismatch_set_as_dupbag_test() {
       value_decoder: decode.string,
     )
   expect_type_mismatch_open(result)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn type_mismatch_bag_as_set_test() {
+pub fn type_mismatch_bag_as_set_test() -> Nil {
   let path = "test_type_mismatch_bs.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -60,10 +61,10 @@ pub fn type_mismatch_bag_as_set_test() {
   let result =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   expect_type_mismatch_open(result)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn type_mismatch_bag_as_dupbag_test() {
+pub fn type_mismatch_bag_as_dupbag_test() -> Nil {
   let path = "test_type_mismatch_bd.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -76,10 +77,10 @@ pub fn type_mismatch_bag_as_dupbag_test() {
       value_decoder: decode.string,
     )
   expect_type_mismatch_open(result)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn type_mismatch_dupbag_as_set_test() {
+pub fn type_mismatch_dupbag_as_set_test() -> Nil {
   let path = "test_type_mismatch_ds.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -92,10 +93,10 @@ pub fn type_mismatch_dupbag_as_set_test() {
   let result =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   expect_type_mismatch_open(result)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn type_mismatch_dupbag_as_bag_test() {
+pub fn type_mismatch_dupbag_as_bag_test() -> Nil {
   let path = "test_type_mismatch_db.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -108,10 +109,10 @@ pub fn type_mismatch_dupbag_as_bag_test() {
   let result =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   expect_type_mismatch_open(result)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn already_open_with_conflicting_access_test() {
+pub fn already_open_with_conflicting_access_test() -> Nil {
   let path = "test_already_open_access.dets"
   let assert Ok(table) =
     set.open_with_access(
@@ -131,7 +132,7 @@ pub fn already_open_with_conflicting_access_test() {
     )
   result |> expect.to_equal(Error(slate.AlreadyOpen))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── insert_new on bag tables (OTP insert_new test) ──────────────────────
@@ -140,7 +141,7 @@ pub fn already_open_with_conflicting_access_test() {
 // Slate bags don't expose insert_new (by design), but we can verify
 // the deduplication behavior that makes insert_new less useful for bags.
 
-pub fn bag_insert_same_key_different_values_test() {
+pub fn bag_insert_same_key_different_values_test() -> Nil {
   let path = "test_bag_insert_diff.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -152,19 +153,19 @@ pub fn bag_insert_same_key_different_values_test() {
   list.contains(values, "first") |> expect.to_be_true()
   list.contains(values, "second") |> expect.to_be_true()
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Very large key count triggering rehash (OTP-4906) ───────────────────
 // OTP tests with 256*512 + 400 = 131472 keys.
 // We use 5000 keys as a meaningful stress test without being too slow.
 
-pub fn set_large_key_count_stress_test() {
+pub fn set_large_key_count_stress_test() -> Nil {
   let path = "test_set_stress.dets"
   let n = 5000
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
-  let entries = range(0, n - 1) |> list.map(fn(i) { #(i, i * 3) })
+  let entries = test_helpers.range(0, n - 1) |> list.map(fn(i) { #(i, i * 3) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   set.size(table) |> expect.to_equal(Ok(n))
   // Verify first, middle, last
@@ -172,7 +173,7 @@ pub fn set_large_key_count_stress_test() {
   let assert Ok(7500) = set.lookup(table, key: 2500)
   let assert Ok(14_997) = set.lookup(table, key: 4999)
   // Delete half
-  range(0, 2499)
+  test_helpers.range(0, 2499)
   |> list.each(fn(i) {
     let assert Ok(Nil) = set.delete_key(table, key: i)
     Nil
@@ -181,15 +182,15 @@ pub fn set_large_key_count_stress_test() {
   // Remaining keys still accessible
   let assert Ok(7500) = set.lookup(table, key: 2500)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_large_key_count_persistence_test() {
+pub fn set_large_key_count_persistence_test() -> Nil {
   let path = "test_set_stress_persist.dets"
   let n = 3000
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
-  let entries = range(0, n - 1) |> list.map(fn(i) { #(i, i) })
+  let entries = test_helpers.range(0, n - 1) |> list.map(fn(i) { #(i, i) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   let assert Ok(Nil) = set.close(table)
   // Reopen and verify all entries survived
@@ -200,35 +201,36 @@ pub fn set_large_key_count_persistence_test() {
   let assert Ok(1500) = set.lookup(table2, key: 1500)
   let assert Ok(2999) = set.lookup(table2, key: 2999)
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Fold with large dataset ─────────────────────────────────────────────
 
-pub fn set_fold_large_dataset_test() {
+pub fn set_fold_large_dataset_test() -> Nil {
   let path = "test_set_fold_large.dets"
   let n = 2000
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
-  let entries = range(1, n) |> list.map(fn(i) { #(int.to_string(i), i) })
+  let entries =
+    test_helpers.range(1, n) |> list.map(fn(i) { #(int.to_string(i), i) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   let assert Ok(sum) = set.fold(table, 0, fn(acc, _k, v) { acc + v })
   // Sum of 1..2000 = 2000 * 2001 / 2 = 2_001_000
   sum |> expect.to_equal(2_001_000)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag fold large ──────────────────────────────────────────────────────
 
-pub fn bag_fold_large_dataset_test() {
+pub fn bag_fold_large_dataset_test() -> Nil {
   let path = "test_bag_fold_large.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.int, value_decoder: decode.int)
   // 200 keys × 5 values each = 1000 entries
-  range(0, 199)
+  test_helpers.range(0, 199)
   |> list.each(fn(key) {
-    range(0, 4)
+    test_helpers.range(0, 4)
     |> list.each(fn(val) {
       let assert Ok(Nil) = bag.insert(table, key, val)
       Nil
@@ -238,12 +240,12 @@ pub fn bag_fold_large_dataset_test() {
   let assert Ok(count) = bag.fold(table, 0, fn(acc, _k, _v) { acc + 1 })
   count |> expect.to_equal(1000)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── delete_object on set with wrong value (OTP del_obj_test) ────────────
 
-pub fn set_delete_object_preserves_on_mismatch_test() {
+pub fn set_delete_object_preserves_on_mismatch_test() -> Nil {
   let path = "test_set_del_obj_mismatch.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -254,22 +256,22 @@ pub fn set_delete_object_preserves_on_mismatch_test() {
   let assert Ok(42) = set.lookup(table, key: "x")
   set.size(table) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── insert_list with empty list ─────────────────────────────────────────
 
-pub fn bag_insert_list_empty_test() {
+pub fn bag_insert_list_empty_test() -> Nil {
   let path = "test_bag_ins_list_empty.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let assert Ok(Nil) = bag.insert_list(table, [])
   bag.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_insert_list_empty_test() {
+pub fn dupbag_insert_list_empty_test() -> Nil {
   let path = "test_dupbag_ins_list_empty.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -280,12 +282,12 @@ pub fn dupbag_insert_list_empty_test() {
   let assert Ok(Nil) = duplicate_bag.insert_list(table, [])
   duplicate_bag.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── to_list on bags ─────────────────────────────────────────────────────
 
-pub fn bag_to_list_test() {
+pub fn bag_to_list_test() -> Nil {
   let path = "test_bag_to_list_full.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -295,23 +297,23 @@ pub fn bag_to_list_test() {
   let assert Ok(entries) = bag.to_list(table)
   entries |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag to_list empty ───────────────────────────────────────────────────
 
-pub fn bag_to_list_empty_test() {
+pub fn bag_to_list_empty_test() -> Nil {
   let path = "test_bag_to_list_empty.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
   bag.to_list(table) |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag to_list empty ──────────────────────────────────────────
 
-pub fn dupbag_to_list_empty_test() {
+pub fn dupbag_to_list_empty_test() -> Nil {
   let path = "test_dupbag_to_list_empty.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -321,12 +323,12 @@ pub fn dupbag_to_list_empty_test() {
     )
   duplicate_bag.to_list(table) |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Multiple insert_list calls accumulate in bags ───────────────────────
 
-pub fn bag_multiple_insert_list_test() {
+pub fn bag_multiple_insert_list_test() -> Nil {
   let path = "test_bag_multi_ins_list.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -335,10 +337,10 @@ pub fn bag_multiple_insert_list_test() {
   let assert Ok(values) = bag.lookup(table, key: "k")
   values |> list.length |> expect.to_equal(4)
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_multiple_insert_list_test() {
+pub fn dupbag_multiple_insert_list_test() -> Nil {
   let path = "test_dupbag_multi_ins_list.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -352,14 +354,14 @@ pub fn dupbag_multiple_insert_list_test() {
   // All 4 entries stored (duplicate_bag keeps everything)
   values |> list.length |> expect.to_equal(4)
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Concurrent shared access (OTP many_clients adapted) ─────────────────
 // DETS supports multiple openers of the same table from the same node.
 // All share the same underlying table.
 
-pub fn set_shared_write_read_test() {
+pub fn set_shared_write_read_test() -> Nil {
   let path = "test_set_shared_wr.dets"
   let assert Ok(t1) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -382,10 +384,10 @@ pub fn set_shared_write_read_test() {
   let assert Ok(Nil) = set.close(t1)
   let assert Ok(Nil) = set.close(t2)
   let assert Ok(Nil) = set.close(t3)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_shared_overwrite_test() {
+pub fn set_shared_overwrite_test() -> Nil {
   let path = "test_set_shared_ow.dets"
   let assert Ok(t1) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -398,10 +400,10 @@ pub fn set_shared_overwrite_test() {
   set.size(t1) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = set.close(t1)
   let assert Ok(Nil) = set.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_shared_delete_visible_test() {
+pub fn set_shared_delete_visible_test() -> Nil {
   let path = "test_set_shared_del.dets"
   let assert Ok(t1) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -413,10 +415,10 @@ pub fn set_shared_delete_visible_test() {
   set.lookup(t1, key: "key") |> expect.to_equal(Error(slate.NotFound))
   let assert Ok(Nil) = set.close(t1)
   let assert Ok(Nil) = set.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_shared_accumulate_test() {
+pub fn bag_shared_accumulate_test() -> Nil {
   let path = "test_bag_shared_acc.dets"
   let assert Ok(t1) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -430,13 +432,13 @@ pub fn bag_shared_accumulate_test() {
   values |> list.length |> expect.to_equal(3)
   let assert Ok(Nil) = bag.close(t1)
   let assert Ok(Nil) = bag.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Repair: ForceRepair rewrites healthy file ───────────────────────────
 // OTP: force repair on a clean file should work and preserve data.
 
-pub fn set_force_repair_preserves_data_test() {
+pub fn set_force_repair_preserves_data_test() -> Nil {
   let path = "test_set_force_repair_data.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -455,10 +457,10 @@ pub fn set_force_repair_preserves_data_test() {
   let assert Ok(3) = set.lookup(table2, key: "c")
   set.size(table2) |> expect.to_equal(Ok(3))
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_force_repair_preserves_data_test() {
+pub fn bag_force_repair_preserves_data_test() -> Nil {
   let path = "test_bag_force_repair_data.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -475,10 +477,10 @@ pub fn bag_force_repair_preserves_data_test() {
   let assert Ok(values) = bag.lookup(table2, key: "k")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_force_repair_preserves_data_test() {
+pub fn dupbag_force_repair_preserves_data_test() -> Nil {
   let path = "test_dupbag_force_repair_data.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -499,5 +501,5 @@ pub fn dupbag_force_repair_preserves_data_test() {
   let assert Ok(values) = duplicate_bag.lookup(table2, key: "k")
   values |> list.length |> expect.to_equal(2)
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/ffi_error_test.gleam
+++ b/test/ffi_error_test.gleam
@@ -2,7 +2,7 @@ import gleam/dynamic/decode
 import slate
 import slate/set
 import startest/expect
-import test_helpers.{cleanup}
+import test_helpers
 
 @external(erlang, "corruption_test_helpers_ffi", "write_garbage")
 fn write_garbage(path: String) -> Result(Nil, Nil)
@@ -10,7 +10,7 @@ fn write_garbage(path: String) -> Result(Nil, Nil)
 @external(erlang, "corruption_test_ffi", "corrupt_byte")
 fn corrupt_byte(path: String, position: Int) -> Result(Nil, Nil)
 
-pub fn error_code_and_message_helpers_test() {
+pub fn error_code_and_message_helpers_test() -> Nil {
   slate.error_code(slate.NotFound) |> expect.to_equal("not_found")
   slate.error_code(slate.UnexpectedError("boom"))
   |> expect.to_equal("unexpected_error")
@@ -31,7 +31,7 @@ pub fn error_code_and_message_helpers_test() {
   )
 }
 
-pub fn not_a_dets_file_error_test() {
+pub fn not_a_dets_file_error_test() -> Nil {
   let path = "test_not_a_dets_error.dets"
   // Write garbage to simulate a non-DETS file
   let assert Ok(Nil) = write_garbage(path)
@@ -42,19 +42,11 @@ pub fn not_a_dets_file_error_test() {
       key_decoder: decode.string,
       value_decoder: decode.string,
     )
-  case result {
-    Error(slate.NotADetsFile) -> Nil
-    Error(slate.UnexpectedError(_)) -> Nil
-    Error(_) -> Nil
-    Ok(table) -> {
-      let assert Ok(Nil) = set.close(table)
-      Nil
-    }
-  }
-  cleanup(path)
+  result |> expect.to_equal(Error(slate.NotADetsFile))
+  test_helpers.cleanup(path)
 }
 
-pub fn needs_repair_error_test() {
+pub fn needs_repair_error_test() -> Nil {
   let path = "test_needs_repair_error.dets"
   // Create a valid table
   let assert Ok(table) =
@@ -71,18 +63,11 @@ pub fn needs_repair_error_test() {
       key_decoder: decode.string,
       value_decoder: decode.string,
     )
-  case result {
-    Error(slate.NeedsRepair) -> Nil
-    Error(_) -> Nil
-    Ok(table2) -> {
-      let assert Ok(Nil) = set.close(table2)
-      Nil
-    }
-  }
-  cleanup(path)
+  result |> expect.to_equal(Error(slate.NeedsRepair))
+  test_helpers.cleanup(path)
 }
 
-pub fn set_info_closed_table_returns_table_does_not_exist_test() {
+pub fn set_info_closed_table_returns_table_does_not_exist_test() -> Nil {
   let path = "test_set_info_closed_table.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -91,5 +76,5 @@ pub fn set_info_closed_table_returns_table_does_not_exist_test() {
 
   set.info(table) |> expect.to_equal(Error(slate.TableDoesNotExist))
 
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/fold_results_test.gleam
+++ b/test/fold_results_test.gleam
@@ -5,11 +5,11 @@ import slate/bag
 import slate/duplicate_bag
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, range}
+import test_helpers
 
 // ── Success path ────────────────────────────────────────────────────────
 
-pub fn set_fold_results_success_test() {
+pub fn set_fold_results_success_test() -> Nil {
   let path = "test_set_fold_results_ok.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -27,10 +27,10 @@ pub fn set_fold_results_success_test() {
   sum |> expect.to_equal(60)
 
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_fold_results_success_test() {
+pub fn bag_fold_results_success_test() -> Nil {
   let path = "test_bag_fold_results_ok.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -48,10 +48,10 @@ pub fn bag_fold_results_success_test() {
   sum |> expect.to_equal(6)
 
   let assert Ok(Nil) = bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_fold_results_success_test() {
+pub fn duplicate_bag_fold_results_success_test() -> Nil {
   let path = "test_dupbag_fold_results_ok.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -73,10 +73,10 @@ pub fn duplicate_bag_fold_results_success_test() {
   sum |> expect.to_equal(5)
 
   let assert Ok(Nil) = duplicate_bag.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_fold_results_empty_table_test() {
+pub fn set_fold_results_empty_table_test() -> Nil {
   let path = "test_set_fold_results_empty.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -85,17 +85,20 @@ pub fn set_fold_results_empty_table_test() {
   count |> expect.to_equal(0)
 
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Partial failure — skip errors ───────────────────────────────────────
 
-pub fn set_fold_results_skips_decode_errors_test() {
+pub fn set_fold_results_skips_decode_errors_test() -> Nil {
   let path = "test_set_fold_results_skip.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
-    set.insert_list(table, range(1, 50) |> list.map(fn(i) { #(i, i * 10) }))
+    set.insert_list(
+      table,
+      test_helpers.range(1, 50) |> list.map(fn(i) { #(i, i * 10) }),
+    )
   let assert Ok(Nil) = set.close(table)
 
   // Reopen with wrong value decoder
@@ -113,15 +116,18 @@ pub fn set_fold_results_skips_decode_errors_test() {
   items |> expect.to_equal([])
 
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_fold_results_skips_decode_errors_test() {
+pub fn bag_fold_results_skips_decode_errors_test() -> Nil {
   let path = "test_bag_fold_results_skip.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
-    bag.insert_list(table, range(1, 10) |> list.map(fn(i) { #(i, i * 10) }))
+    bag.insert_list(
+      table,
+      test_helpers.range(1, 10) |> list.map(fn(i) { #(i, i * 10) }),
+    )
   let assert Ok(Nil) = bag.close(table)
 
   let assert Ok(table2) =
@@ -137,17 +143,17 @@ pub fn bag_fold_results_skips_decode_errors_test() {
   items |> expect.to_equal([])
 
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_fold_results_skips_decode_errors_test() {
+pub fn duplicate_bag_fold_results_skips_decode_errors_test() -> Nil {
   let path = "test_dupbag_fold_results_skip.dets"
   let assert Ok(table) =
     duplicate_bag.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
     duplicate_bag.insert_list(
       table,
-      range(1, 10) |> list.map(fn(i) { #(i, i * 10) }),
+      test_helpers.range(1, 10) |> list.map(fn(i) { #(i, i * 10) }),
     )
   let assert Ok(Nil) = duplicate_bag.close(table)
 
@@ -168,17 +174,20 @@ pub fn duplicate_bag_fold_results_skips_decode_errors_test() {
   items |> expect.to_equal([])
 
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Partial failure — partition pattern ─────────────────────────────────
 
-pub fn set_fold_results_partition_test() {
+pub fn set_fold_results_partition_test() -> Nil {
   let path = "test_set_fold_results_partition.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
-    set.insert_list(table, range(1, 20) |> list.map(fn(i) { #(i, i * 10) }))
+    set.insert_list(
+      table,
+      test_helpers.range(1, 20) |> list.map(fn(i) { #(i, i * 10) }),
+    )
   let assert Ok(Nil) = set.close(table)
 
   // Reopen with wrong decoder — all entries will fail
@@ -196,18 +205,21 @@ pub fn set_fold_results_partition_test() {
   list.length(bad) |> expect.to_equal(20)
 
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Visits all entries (no short-circuit) ───────────────────────────────
 
-pub fn set_fold_results_visits_all_entries_test() {
+pub fn set_fold_results_visits_all_entries_test() -> Nil {
   let path = "test_set_fold_results_all.dets"
   let count = 50
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
-    set.insert_list(table, range(1, count) |> list.map(fn(i) { #(i, i * 10) }))
+    set.insert_list(
+      table,
+      test_helpers.range(1, count) |> list.map(fn(i) { #(i, i * 10) }),
+    )
   let assert Ok(Nil) = set.close(table)
 
   // Wrong decoder — every entry fails, but we count them all
@@ -219,12 +231,12 @@ pub fn set_fold_results_visits_all_entries_test() {
   visited |> expect.to_equal(count)
 
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Collect keys with correct key decoder ───────────────────────────────
 
-pub fn set_fold_results_collects_keys_test() {
+pub fn set_fold_results_collects_keys_test() -> Nil {
   let path = "test_set_fold_results_keys.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -240,5 +252,5 @@ pub fn set_fold_results_collects_keys_test() {
   keys |> list.sort(string.compare) |> expect.to_equal(["a", "b", "c"])
 
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/fold_short_circuit_test.gleam
+++ b/test/fold_short_circuit_test.gleam
@@ -5,21 +5,21 @@ import slate/bag
 import slate/duplicate_bag
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, did_panic, range}
+import test_helpers
 
 @external(erlang, "fold_short_circuit_test_ffi", "count_ffi_fold_invocations")
 fn count_ffi_fold_invocations(table: table_type) -> Int
 
 const entry_count = 50
 
-pub fn set_fold_short_circuits_on_decode_error_test() {
+pub fn set_fold_short_circuits_on_decode_error_test() -> Nil {
   let path = "test_set_fold_short_circuit.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
     set.insert_list(
       table,
-      range(1, entry_count) |> list.map(fn(i) { #(i, i * 10) }),
+      test_helpers.range(1, entry_count) |> list.map(fn(i) { #(i, i * 10) }),
     )
   let assert Ok(Nil) = set.close(table)
 
@@ -36,17 +36,17 @@ pub fn set_fold_short_circuits_on_decode_error_test() {
   invocations |> expect.to_equal(1)
 
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_fold_short_circuits_on_decode_error_test() {
+pub fn bag_fold_short_circuits_on_decode_error_test() -> Nil {
   let path = "test_bag_fold_short_circuit.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
     bag.insert_list(
       table,
-      range(1, entry_count) |> list.map(fn(i) { #(i, i * 10) }),
+      test_helpers.range(1, entry_count) |> list.map(fn(i) { #(i, i * 10) }),
     )
   let assert Ok(Nil) = bag.close(table)
 
@@ -60,17 +60,17 @@ pub fn bag_fold_short_circuits_on_decode_error_test() {
   invocations |> expect.to_equal(1)
 
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn duplicate_bag_fold_short_circuits_on_decode_error_test() {
+pub fn duplicate_bag_fold_short_circuits_on_decode_error_test() -> Nil {
   let path = "test_dupbag_fold_short_circuit.dets"
   let assert Ok(table) =
     duplicate_bag.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let assert Ok(Nil) =
     duplicate_bag.insert_list(
       table,
-      range(1, entry_count) |> list.map(fn(i) { #(i, i * 10) }),
+      test_helpers.range(1, entry_count) |> list.map(fn(i) { #(i, i * 10) }),
     )
   let assert Ok(Nil) = duplicate_bag.close(table)
 
@@ -88,16 +88,16 @@ pub fn duplicate_bag_fold_short_circuits_on_decode_error_test() {
   invocations |> expect.to_equal(1)
 
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_fold_callback_panic_propagates_test() {
+pub fn set_fold_callback_panic_propagates_test() -> Nil {
   let path = "test_set_fold_panic.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, 1, "one")
 
-  did_panic(fn() {
+  test_helpers.did_panic(fn() {
     let _ =
       set.fold(table, "", fn(acc, _k, v) {
         let _ = acc <> v
@@ -109,16 +109,16 @@ pub fn set_fold_callback_panic_propagates_test() {
 
   let assert Ok("one") = set.lookup(table, key: 1)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_fold_results_callback_panic_propagates_test() {
+pub fn set_fold_results_callback_panic_propagates_test() -> Nil {
   let path = "test_set_fold_results_panic.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, 1, "one")
 
-  did_panic(fn() {
+  test_helpers.did_panic(fn() {
     let _ =
       set.fold_results(table, 0, fn(acc, _entry) {
         let _ = acc
@@ -130,5 +130,5 @@ pub fn set_fold_results_callback_panic_propagates_test() {
 
   let assert Ok("one") = set.lookup(table, key: 1)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/is_dets_file_test.gleam
+++ b/test/is_dets_file_test.gleam
@@ -1,14 +1,15 @@
-/// Tests for the is_dets_file utility function.
-/// Adapted from OTP dets_SUITE is_dets_file and open_file tests.
+//// Tests for the is_dets_file utility function.
+//// Adapted from OTP dets_SUITE is_dets_file and open_file tests.
+
 import gleam/dynamic/decode
 import slate
 import slate/set
 import startest/expect
-import test_helpers.{cleanup}
+import test_helpers
 
 // ── Valid DETS file ─────────────────────────────────────────────────────
 
-pub fn is_dets_file_valid_test() {
+pub fn is_dets_file_valid_test() -> Nil {
   let path = "test_is_dets_valid.dets"
   // Create a DETS file
   let assert Ok(table) =
@@ -17,33 +18,33 @@ pub fn is_dets_file_valid_test() {
   let assert Ok(Nil) = set.close(table)
   // Check it
   slate.is_dets_file(path) |> expect.to_equal(Ok(True))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Non-DETS file ───────────────────────────────────────────────────────
 
-pub fn is_dets_file_not_dets_test() {
+pub fn is_dets_file_not_dets_test() -> Nil {
   let path = "test_is_dets_not.txt"
   // Write a plain text file
   let assert Ok(Nil) = write_file(path, "hello world this is not dets")
   slate.is_dets_file(path) |> expect.to_equal(Ok(False))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Empty DETS file (opened and closed without data) ────────────────────
 
-pub fn is_dets_file_empty_table_test() {
+pub fn is_dets_file_empty_table_test() -> Nil {
   let path = "test_is_dets_empty.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.close(table)
   slate.is_dets_file(path) |> expect.to_equal(Ok(True))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Non-existent file ───────────────────────────────────────────────────
 
-pub fn is_dets_file_nonexistent_test() {
+pub fn is_dets_file_nonexistent_test() -> Nil {
   let result = slate.is_dets_file("nonexistent_file_12345.dets")
   // Should return an error (file doesn't exist)
   case result {
@@ -57,7 +58,7 @@ pub fn is_dets_file_nonexistent_test() {
 
 // ── DETS file with data, verified after reopen ──────────────────────────
 
-pub fn is_dets_file_after_use_test() {
+pub fn is_dets_file_after_use_test() -> Nil {
   let path = "test_is_dets_used.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -67,7 +68,7 @@ pub fn is_dets_file_after_use_test() {
   let assert Ok(Nil) = set.sync(table)
   let assert Ok(Nil) = set.close(table)
   slate.is_dets_file(path) |> expect.to_equal(Ok(True))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Helper: write a plain file ──────────────────────────────────────────

--- a/test/pool_exhaustion_test.gleam
+++ b/test/pool_exhaustion_test.gleam
@@ -1,35 +1,36 @@
-/// Tests for the bounded table-name pool in `dets_ffi.erl`.
-///
-/// The pool has 4096 slots (`?TABLE_NAME_POOL_SIZE`). When a table is opened,
-/// `allocate_table_name/1` hashes the canonical path to pick a starting slot
-/// and probes linearly until it finds a free one. If every slot is occupied by
-/// a *different* open table, it raises `erlang:error(no_available_table_name)`,
-/// which `do_open/4`'s try-catch translates to `TableNamePoolExhausted`.
-///
-/// Opening 4096 real DETS files in a unit test is too expensive, so instead
-/// these tests exercise the pool's slot-reuse logic at a smaller scale:
-///
-///   1. Open several tables concurrently and verify they all succeed.
-///   2. Close them and reopen new tables to confirm freed slots are reused.
-///   3. Verify that reopening an already-open path returns the same handle
-///      (no extra slot consumed).
-///
-/// The exhaustion error path (`TableNamePoolExhausted`) has
-/// been verified by code review of `dets_ffi.erl` lines 92-93.
+//// Tests for the bounded table-name pool in `dets_ffi.erl`.
+////
+//// The pool has 4096 slots (`?TABLE_NAME_POOL_SIZE`). When a table is opened,
+//// `allocate_table_name/1` hashes the canonical path to pick a starting slot
+//// and probes linearly until it finds a free one. If every slot is occupied by
+//// a *different* open table, it raises `erlang:error(no_available_table_name)`,
+//// which `do_open/4`'s try-catch translates to `TableNamePoolExhausted`.
+////
+//// Opening 4096 real DETS files in a unit test is too expensive, so instead
+//// these tests exercise the pool's slot-reuse logic at a smaller scale:
+////
+////   1. Open several tables concurrently and verify they all succeed.
+////   2. Close them and reopen new tables to confirm freed slots are reused.
+////   3. Verify that reopening an already-open path returns the same handle
+////      (no extra slot consumed).
+////
+//// The exhaustion error path (`TableNamePoolExhausted`) has
+//// been verified by code review of `dets_ffi.erl` lines 92-93.
+
 import gleam/dynamic/decode
 import gleam/int
 import gleam/list
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, range}
+import test_helpers
 
 // ── Pool: multiple concurrent opens ─────────────────────────────────────
 
 /// Open several tables concurrently to verify slot allocation works.
-pub fn pool_concurrent_opens_test() {
+pub fn pool_concurrent_opens_test() -> Nil {
   let count = 20
   let paths =
-    range(1, count)
+    test_helpers.range(1, count)
     |> list.map(fn(i) { "test_pool_concurrent_" <> int.to_string(i) <> ".dets" })
 
   // Open all tables
@@ -51,18 +52,18 @@ pub fn pool_concurrent_opens_test() {
   list.each(tables, fn(table) {
     let assert Ok(Nil) = set.close(table)
   })
-  list.each(paths, cleanup)
+  list.each(paths, test_helpers.cleanup)
 }
 
 // ── Pool: slot reuse after close ────────────────────────────────────────
 
 /// Close tables and reopen with new paths to confirm pool slots are recycled.
-pub fn pool_slot_reuse_after_close_test() {
+pub fn pool_slot_reuse_after_close_test() -> Nil {
   let count = 10
 
   // Phase 1: open tables with one set of paths
   let paths_a =
-    range(1, count)
+    test_helpers.range(1, count)
     |> list.map(fn(i) { "test_pool_reuse_a_" <> int.to_string(i) <> ".dets" })
   let tables_a =
     list.map(paths_a, fn(path) {
@@ -78,7 +79,7 @@ pub fn pool_slot_reuse_after_close_test() {
 
   // Phase 2: open tables with different paths — these should reuse freed slots
   let paths_b =
-    range(1, count)
+    test_helpers.range(1, count)
     |> list.map(fn(i) { "test_pool_reuse_b_" <> int.to_string(i) <> ".dets" })
   let tables_b =
     list.map(paths_b, fn(path) {
@@ -98,15 +99,15 @@ pub fn pool_slot_reuse_after_close_test() {
   list.each(tables_b, fn(table) {
     let assert Ok(Nil) = set.close(table)
   })
-  list.each(paths_a, cleanup)
-  list.each(paths_b, cleanup)
+  list.each(paths_a, test_helpers.cleanup)
+  list.each(paths_b, test_helpers.cleanup)
 }
 
 // ── Pool: reopening same path reuses handle ─────────────────────────────
 
 /// Opening the same path twice should return the existing table handle
 /// without consuming an additional pool slot.
-pub fn pool_reopen_same_path_test() {
+pub fn pool_reopen_same_path_test() -> Nil {
   let path = "test_pool_same_path.dets"
 
   let assert Ok(table1) =
@@ -120,5 +121,5 @@ pub fn pool_reopen_same_path_test() {
   val |> expect.to_equal("from_first_open")
 
   let assert Ok(Nil) = set.close(table1)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/set_otp_test.gleam
+++ b/test/set_otp_test.gleam
@@ -1,6 +1,7 @@
-/// Tests adapted from the Erlang/OTP dets_SUITE.erl test suite.
-/// These exercise edge cases, boundary conditions, and behaviors
-/// documented in the official DETS implementation.
+//// Tests adapted from the Erlang/OTP dets_SUITE.erl test suite.
+//// These exercise edge cases, boundary conditions, and behaviors
+//// documented in the official DETS implementation.
+
 import gleam/dynamic/decode
 import gleam/int
 import gleam/list
@@ -8,13 +9,13 @@ import gleam/string
 import slate
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, range, unsafe_decoder}
+import test_helpers
 
 // ── Integer vs Float key distinction (OTP-4738) ─────────────────────────
 // Erlang treats integer and float keys as distinct in DETS.
 // 1 and 1.0 are different keys.
 
-pub fn set_int_key_test() {
+pub fn set_int_key_test() -> Nil {
   let path = "test_set_int_key.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -24,10 +25,10 @@ pub fn set_int_key_test() {
   let assert Ok("integer_two") = set.lookup(table, key: 2)
   set.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_float_key_test() {
+pub fn set_float_key_test() -> Nil {
   let path = "test_set_float_key.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.float, value_decoder: decode.string)
@@ -37,10 +38,10 @@ pub fn set_float_key_test() {
   let assert Ok("float_two_half") = set.lookup(table, key: 2.5)
   set.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_negative_int_key_test() {
+pub fn set_negative_int_key_test() -> Nil {
   let path = "test_set_neg_int.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -48,10 +49,10 @@ pub fn set_negative_int_key_test() {
   let assert Ok(Nil) = set.insert(table, i, "int")
   let assert Ok("int") = set.lookup(table, key: i)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_negative_float_key_test() {
+pub fn set_negative_float_key_test() -> Nil {
   let path = "test_set_neg_float.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.float, value_decoder: decode.string)
@@ -59,32 +60,32 @@ pub fn set_negative_float_key_test() {
   let assert Ok(Nil) = set.insert(table, f, "float")
   let assert Ok("float") = set.lookup(table, key: f)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_zero_int_key_test() {
+pub fn set_zero_int_key_test() -> Nil {
   let path = "test_set_zero_int.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, 0, "int_zero")
   let assert Ok("int_zero") = set.lookup(table, key: 0)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_zero_float_key_test() {
+pub fn set_zero_float_key_test() -> Nil {
   let path = "test_set_zero_float.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.float, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, 0.0, "float_zero")
   let assert Ok("float_zero") = set.lookup(table, key: 0.0)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Boundary integers ───────────────────────────────────────────────────
 
-pub fn set_negative_integer_keys_test() {
+pub fn set_negative_integer_keys_test() -> Nil {
   let path = "test_set_neg_keys.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -96,10 +97,10 @@ pub fn set_negative_integer_keys_test() {
   let assert Ok("zero") = set.lookup(table, key: 0)
   set.size(table) |> expect.to_equal(Ok(3))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_large_integer_keys_test() {
+pub fn set_large_integer_keys_test() -> Nil {
   let path = "test_set_large_int.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -111,26 +112,31 @@ pub fn set_large_integer_keys_test() {
   let assert Ok("big") = set.lookup(table, key: big)
   let assert Ok("neg_big") = set.lookup(table, key: neg_big)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Very large values ───────────────────────────────────────────────────
 // OTP tests objects > 2kB to exercise "bigger buddy" allocation.
 
-pub fn set_large_tuple_value_test() {
+pub fn set_large_tuple_value_test() -> Nil {
   let path = "test_set_large_tuple.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    set.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   // Create a large list value (simulates large tuple from OTP)
-  let big_list = range(0, 999) |> list.map(fn(i) { #(i, "foobar") })
+  let big_list =
+    test_helpers.range(0, 999) |> list.map(fn(i) { #(i, "foobar") })
   let assert Ok(Nil) = set.insert(table, "big", big_list)
   let assert Ok(result) = set.lookup(table, key: "big")
   result |> list.length |> expect.to_equal(1000)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_large_string_value_test() {
+pub fn set_large_string_value_test() -> Nil {
   let path = "test_set_large_string.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -140,10 +146,10 @@ pub fn set_large_string_value_test() {
   let assert Ok(result) = set.lookup(table, key: "key")
   string.length(result) |> expect.to_equal(5000)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_large_value_persistence_test() {
+pub fn set_large_value_persistence_test() -> Nil {
   let path = "test_set_large_persist.dets"
   let big_string = string.repeat("X", 5000)
   let assert Ok(table) =
@@ -156,12 +162,12 @@ pub fn set_large_value_persistence_test() {
   let assert Ok(result) = set.lookup(table2, key: "big")
   string.length(result) |> expect.to_equal(5000)
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Unicode keys and values ─────────────────────────────────────────────
 
-pub fn set_unicode_keys_test() {
+pub fn set_unicode_keys_test() -> Nil {
   let path = "test_set_unicode_keys.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -175,10 +181,10 @@ pub fn set_unicode_keys_test() {
   let assert Ok("emoji") = set.lookup(table, key: "émojis 🎉🚀")
   set.size(table) |> expect.to_equal(Ok(4))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_unicode_values_test() {
+pub fn set_unicode_values_test() -> Nil {
   let path = "test_set_unicode_vals.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -187,10 +193,10 @@ pub fn set_unicode_values_test() {
   let assert Ok("こんにちは世界") = set.lookup(table, key: "greet")
   let assert Ok("🎸🎵🎶") = set.lookup(table, key: "emoji")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_unicode_persistence_test() {
+pub fn set_unicode_persistence_test() -> Nil {
   let path = "test_set_unicode_persist.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -200,16 +206,16 @@ pub fn set_unicode_persistence_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok("value_über") = set.lookup(table2, key: "key_café")
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Many open/close cycles (stress test) ────────────────────────────────
 // OTP tests process/port leak detection across cycles.
 
-pub fn set_many_open_close_cycles_test() {
+pub fn set_many_open_close_cycles_test() -> Nil {
   let path = "test_set_many_cycles.dets"
   // 10 cycles of open/write/close/reopen/verify
-  range(1, 10)
+  test_helpers.range(1, 10)
   |> list.each(fn(i) {
     let assert Ok(table) =
       set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -224,7 +230,7 @@ pub fn set_many_open_close_cycles_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let assert Ok(10) = set.lookup(table, key: "round")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Overwrite with different value shapes ───────────────────────────────
@@ -232,7 +238,7 @@ pub fn set_many_open_close_cycles_test() {
 // completely different term shape in DETS. Gleam's type system
 // prevents this in normal code, but within the same type it's valid.
 
-pub fn set_overwrite_different_lengths_test() {
+pub fn set_overwrite_different_lengths_test() -> Nil {
   let path = "test_set_overwrite_diff.dets"
   let assert Ok(table) =
     set.open(
@@ -247,20 +253,20 @@ pub fn set_overwrite_different_lengths_test() {
   let assert Ok([]) = set.lookup(table, key: "key")
   set.size(table) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Large dataset triggering rehash (OTP-4906) ──────────────────────────
 // > 128k keys causes DETS to rehash internally.
 
-pub fn set_rehash_large_key_count_test() {
+pub fn set_rehash_large_key_count_test() -> Nil {
   let path = "test_set_rehash.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.int)
   let n = 2000
   // Insert n entries
   let entries =
-    range(0, n - 1)
+    test_helpers.range(0, n - 1)
     |> list.map(fn(i) { #(i, i * 2) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   set.size(table) |> expect.to_equal(Ok(n))
@@ -269,12 +275,12 @@ pub fn set_rehash_large_key_count_test() {
   let assert Ok(1998) = set.lookup(table, key: 999)
   let assert Ok(3998) = set.lookup(table, key: 1999)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── insert_list overwrites correctly ────────────────────────────────────
 
-pub fn set_insert_list_overwrites_test() {
+pub fn set_insert_list_overwrites_test() -> Nil {
   let path = "test_set_insert_list_ow.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -285,12 +291,12 @@ pub fn set_insert_list_overwrites_test() {
   let assert Ok(2) = set.lookup(table, key: "b")
   set.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── insert_new with list (OTP insert_new test) ──────────────────────────
 
-pub fn set_insert_new_multiple_test() {
+pub fn set_insert_new_multiple_test() -> Nil {
   let path = "test_set_insert_new_multi.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -302,12 +308,12 @@ pub fn set_insert_new_multiple_test() {
   // Original value preserved
   let assert Ok(1) = set.lookup(table, key: "a")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── delete_all then reuse table ─────────────────────────────────────────
 
-pub fn set_delete_all_then_reuse_test() {
+pub fn set_delete_all_then_reuse_test() -> Nil {
   let path = "test_set_del_all_reuse.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -319,12 +325,12 @@ pub fn set_delete_all_then_reuse_test() {
   let assert Ok(42) = set.lookup(table, key: "x")
   set.size(table) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── delete_all persists across close/reopen ─────────────────────────────
 
-pub fn set_delete_all_persists_test() {
+pub fn set_delete_all_persists_test() -> Nil {
   let path = "test_set_del_all_persist.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -336,12 +342,12 @@ pub fn set_delete_all_persists_test() {
   set.size(table2) |> expect.to_equal(Ok(0))
   set.lookup(table2, key: "key") |> expect.to_equal(Error(slate.NotFound))
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── sync ensures data is on disk ────────────────────────────────────────
 
-pub fn set_sync_then_reopen_test() {
+pub fn set_sync_then_reopen_test() -> Nil {
   let path = "test_set_sync_reopen.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -353,27 +359,31 @@ pub fn set_sync_then_reopen_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok("data") = set.lookup(table2, key: "synced")
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Tuple keys ──────────────────────────────────────────────────────────
 
-pub fn set_tuple_keys_test() {
+pub fn set_tuple_keys_test() -> Nil {
   let path = "test_set_tuple_keys.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: unsafe_decoder(), value_decoder: decode.string)
+    set.open(
+      path,
+      key_decoder: test_helpers.unsafe_decoder(),
+      value_decoder: decode.string,
+    )
   let assert Ok(Nil) = set.insert(table, #("compound", 1), "value_a")
   let assert Ok(Nil) = set.insert(table, #("compound", 2), "value_b")
   let assert Ok("value_a") = set.lookup(table, key: #("compound", 1))
   let assert Ok("value_b") = set.lookup(table, key: #("compound", 2))
   set.size(table) |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bool values ─────────────────────────────────────────────────────────
 
-pub fn set_bool_values_test() {
+pub fn set_bool_values_test() -> Nil {
   let path = "test_set_bool_vals.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.bool)
@@ -382,12 +392,12 @@ pub fn set_bool_values_test() {
   let assert Ok(True) = set.lookup(table, key: "flag_a")
   let assert Ok(False) = set.lookup(table, key: "flag_b")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Float values ────────────────────────────────────────────────────────
 
-pub fn set_float_values_test() {
+pub fn set_float_values_test() -> Nil {
   let path = "test_set_float_vals.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.float)
@@ -398,21 +408,21 @@ pub fn set_float_values_test() {
   let assert Ok(-273.15) = set.lookup(table, key: "neg")
   let assert Ok(0.0) = set.lookup(table, key: "zero")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Mixed batch: insert_list then delete some ───────────────────────────
 
-pub fn set_batch_insert_then_selective_delete_test() {
+pub fn set_batch_insert_then_selective_delete_test() -> Nil {
   let path = "test_set_batch_del.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let entries =
-    range(0, 99)
+    test_helpers.range(0, 99)
     |> list.map(fn(i) { #(int.to_string(i), i) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   // Delete every other key
-  range(0, 49)
+  test_helpers.range(0, 49)
   |> list.each(fn(i) {
     let assert Ok(Nil) = set.delete_key(table, key: int.to_string(i * 2))
     Nil
@@ -425,12 +435,12 @@ pub fn set_batch_insert_then_selective_delete_test() {
   set.lookup(table, key: "0") |> expect.to_equal(Error(slate.NotFound))
   set.lookup(table, key: "98") |> expect.to_equal(Error(slate.NotFound))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── member after delete ─────────────────────────────────────────────────
 
-pub fn set_member_after_delete_test() {
+pub fn set_member_after_delete_test() -> Nil {
   let path = "test_set_member_del.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -439,12 +449,12 @@ pub fn set_member_after_delete_test() {
   let assert Ok(Nil) = set.delete_key(table, key: "key")
   set.member(table, key: "key") |> expect.to_equal(Ok(False))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Fold accumulates in unspecified order ────────────────────────────────
 
-pub fn set_fold_builds_dict_test() {
+pub fn set_fold_builds_dict_test() -> Nil {
   let path = "test_set_fold_dict.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -455,12 +465,12 @@ pub fn set_fold_builds_dict_test() {
   |> list.sort(fn(a, b) { int.compare(a.0, b.0) })
   |> expect.to_equal([#(1, "one"), #(2, "two"), #(3, "three")])
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── with_table propagates callback errors ───────────────────────────────
 
-pub fn set_with_table_propagates_error_test() {
+pub fn set_with_table_propagates_error_test() -> Nil {
   let path = "test_set_with_err_prop.dets"
   let result =
     set.with_table(
@@ -470,12 +480,12 @@ pub fn set_with_table_propagates_error_test() {
       fun: fn(_table) { Error(slate.UnexpectedError("custom error")) },
     )
   result |> expect.to_equal(Error(slate.UnexpectedError("custom error")))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── with_table returns value on success ──────────────────────────────────
 
-pub fn set_with_table_returns_value_test() {
+pub fn set_with_table_returns_value_test() -> Nil {
   let path = "test_set_with_val.dets"
   let result =
     set.with_table(
@@ -489,5 +499,5 @@ pub fn set_with_table_returns_value_test() {
       },
     )
   result |> expect.to_equal(Ok(42))
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/set_test.gleam
+++ b/test/set_test.gleam
@@ -6,19 +6,19 @@ import gleam/string
 import slate
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, did_panic, is_table_open, range, unsafe_decoder}
+import test_helpers
 
 // ── Set: Open / Close ───────────────────────────────────────────────────
 
-pub fn set_open_close_test() {
+pub fn set_open_close_test() -> Nil {
   let path = "test_set_open_close.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_open_with_repair_test() {
+pub fn set_open_with_repair_test() -> Nil {
   let path = "test_set_repair.dets"
   let assert Ok(table) =
     set.open_with(
@@ -28,22 +28,22 @@ pub fn set_open_with_repair_test() {
       value_decoder: decode.string,
     )
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Insert / Lookup ────────────────────────────────────────────────
 
-pub fn set_insert_lookup_test() {
+pub fn set_insert_lookup_test() -> Nil {
   let path = "test_set_insert.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, "key1", "value1")
   let assert Ok("value1") = set.lookup(table, key: "key1")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_insert_overwrites_test() {
+pub fn set_insert_overwrites_test() -> Nil {
   let path = "test_set_overwrite.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -51,20 +51,20 @@ pub fn set_insert_overwrites_test() {
   let assert Ok(Nil) = set.insert(table, "key1", "new")
   let assert Ok("new") = set.lookup(table, key: "key1")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_lookup_not_found_test() {
+pub fn set_lookup_not_found_test() -> Nil {
   let path = "test_set_not_found.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   set.lookup(table, key: "missing")
   |> expect.to_equal(Error(slate.NotFound))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_insert_new_test() {
+pub fn set_insert_new_test() -> Nil {
   let path = "test_set_insert_new.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -73,12 +73,12 @@ pub fn set_insert_new_test() {
   |> expect.to_equal(Error(slate.KeyAlreadyPresent))
   let assert Ok("first") = set.lookup(table, key: "key1")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Member ─────────────────────────────────────────────────────────
 
-pub fn set_member_test() {
+pub fn set_member_test() -> Nil {
   let path = "test_set_member.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -86,12 +86,12 @@ pub fn set_member_test() {
   set.member(table, key: "exists") |> expect.to_equal(Ok(True))
   set.member(table, key: "nope") |> expect.to_equal(Ok(False))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Delete ─────────────────────────────────────────────────────────
 
-pub fn set_delete_key_test() {
+pub fn set_delete_key_test() -> Nil {
   let path = "test_set_delete.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -99,10 +99,10 @@ pub fn set_delete_key_test() {
   let assert Ok(Nil) = set.delete_key(table, key: "key1")
   set.lookup(table, key: "key1") |> expect.to_equal(Error(slate.NotFound))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_delete_all_test() {
+pub fn set_delete_all_test() -> Nil {
   let path = "test_set_delete_all.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -111,12 +111,12 @@ pub fn set_delete_all_test() {
   let assert Ok(Nil) = set.delete_all(table)
   set.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Size ───────────────────────────────────────────────────────────
 
-pub fn set_size_test() {
+pub fn set_size_test() -> Nil {
   let path = "test_set_size.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -126,12 +126,12 @@ pub fn set_size_test() {
   let assert Ok(Nil) = set.insert(table, "c", 3)
   set.size(table) |> expect.to_equal(Ok(3))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: to_list ────────────────────────────────────────────────────────
 
-pub fn set_to_list_test() {
+pub fn set_to_list_test() -> Nil {
   let path = "test_set_to_list.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -143,12 +143,12 @@ pub fn set_to_list_test() {
   |> list.sort(fn(a, b) { string.compare(a.0, b.0) })
   |> expect.to_equal([#("a", 1), #("b", 2)])
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Fold ───────────────────────────────────────────────────────────
 
-pub fn set_fold_test() {
+pub fn set_fold_test() -> Nil {
   let path = "test_set_fold.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -158,24 +158,24 @@ pub fn set_fold_test() {
   let assert Ok(sum) = set.fold(table, 0, fn(acc, _key, val) { acc + val })
   sum |> expect.to_equal(60)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Sync ───────────────────────────────────────────────────────────
 
-pub fn set_sync_test() {
+pub fn set_sync_test() -> Nil {
   let path = "test_set_sync.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, "key", "value")
   let assert Ok(Nil) = set.sync(table)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Insert list ────────────────────────────────────────────────────
 
-pub fn set_insert_list_test() {
+pub fn set_insert_list_test() -> Nil {
   let path = "test_set_insert_list.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -183,12 +183,12 @@ pub fn set_insert_list_test() {
   set.size(table) |> expect.to_equal(Ok(3))
   let assert Ok(1) = set.lookup(table, key: "a")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Persistence ────────────────────────────────────────────────────
 
-pub fn set_persistence_test() {
+pub fn set_persistence_test() -> Nil {
   let path = "test_set_persist.dets"
   // Write and close
   let assert Ok(table) =
@@ -200,12 +200,12 @@ pub fn set_persistence_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok("data") = set.lookup(table2, key: "persistent")
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: with_table ─────────────────────────────────────────────────────
 
-pub fn set_with_table_test() {
+pub fn set_with_table_test() -> Nil {
   let path = "test_set_with_table.dets"
   let assert Ok(Nil) =
     set.with_table(
@@ -219,10 +219,10 @@ pub fn set_with_table_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok("val") = set.lookup(table, key: "key")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_with_table_close_error_propagates_test() {
+pub fn set_with_table_close_error_propagates_test() -> Nil {
   let path = "test_set_with_close_err.dets"
   let result =
     set.with_table(
@@ -239,12 +239,12 @@ pub fn set_with_table_close_error_propagates_test() {
     Ok(_) -> False
   }
   close_error_propagated |> expect.to_be_true()
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_with_table_panic_still_closes_test() {
+pub fn set_with_table_panic_still_closes_test() -> Nil {
   let path = "test_set_with_panic.dets"
-  did_panic(fn() {
+  test_helpers.did_panic(fn() {
     let _ =
       set.with_table(
         path,
@@ -258,15 +258,15 @@ pub fn set_with_table_panic_still_closes_test() {
     Nil
   })
   |> expect.to_be_true()
-  is_table_open(path) |> expect.to_equal(False)
+  test_helpers.is_table_open(path) |> expect.to_equal(False)
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok("val") = set.lookup(table, key: "key")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_with_table_open_error_test() {
+pub fn set_with_table_open_error_test() -> Nil {
   let path = "missing_set_with_table_dir/test_set_with_table_open_error.dets"
   set.with_table(
     path,
@@ -275,10 +275,10 @@ pub fn set_with_table_open_error_test() {
     fun: fn(_table) { Ok(Nil) },
   )
   |> expect.to_equal(Error(slate.FileNotFound))
-  is_table_open(path) |> expect.to_equal(False)
+  test_helpers.is_table_open(path) |> expect.to_equal(False)
 }
 
-pub fn set_path_dot_segments_shares_open_table_test() {
+pub fn set_path_dot_segments_shares_open_table_test() -> Nil {
   let path = "test_set_dot_segments.dets"
   // Use a path with redundant ./ and dir/../ segments
   let alias_path = "./subdir/../test_set_dot_segments.dets"
@@ -295,10 +295,10 @@ pub fn set_path_dot_segments_shares_open_table_test() {
   let assert Ok("v1") = set.lookup(t2, key: "key")
   let assert Ok(Nil) = set.close(t1)
   let assert Ok(Nil) = set.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_path_alias_shares_open_table_test() {
+pub fn set_path_alias_shares_open_table_test() -> Nil {
   let path = "test_set_alias_path.dets"
   let alias_path = "./test_set_alias_path.dets"
   let assert Ok(t1) =
@@ -315,12 +315,12 @@ pub fn set_path_alias_shares_open_table_test() {
   let assert Ok("v2") = set.lookup(t1, key: "key")
   let assert Ok(Nil) = set.close(t1)
   let assert Ok(Nil) = set.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Info ───────────────────────────────────────────────────────────
 
-pub fn set_info_test() {
+pub fn set_info_test() -> Nil {
   let path = "test_set_info.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -329,12 +329,12 @@ pub fn set_info_test() {
   info.object_count |> expect.to_equal(1)
   { info.file_size > 0 } |> expect.to_be_true
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Integer keys ───────────────────────────────────────────────────
 
-pub fn set_integer_keys_test() {
+pub fn set_integer_keys_test() -> Nil {
   let path = "test_set_int_keys.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
@@ -343,22 +343,26 @@ pub fn set_integer_keys_test() {
   let assert Ok("one") = set.lookup(table, key: 1)
   let assert Ok("two") = set.lookup(table, key: 2)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Complex value types ────────────────────────────────────────────
 
-pub fn set_tuple_values_test() {
+pub fn set_tuple_values_test() -> Nil {
   let path = "test_set_tuple_vals.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    set.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   let assert Ok(Nil) = set.insert(table, "point", #(10, 20))
   let assert Ok(#(10, 20)) = set.lookup(table, key: "point")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_list_values_test() {
+pub fn set_list_values_test() -> Nil {
   let path = "test_set_list_vals.dets"
   let assert Ok(table) =
     set.open(
@@ -369,55 +373,67 @@ pub fn set_list_values_test() {
   let assert Ok(Nil) = set.insert(table, "items", [1, 2, 3, 4, 5])
   let assert Ok([1, 2, 3, 4, 5]) = set.lookup(table, key: "items")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_nested_tuple_values_test() {
+pub fn set_nested_tuple_values_test() -> Nil {
   let path = "test_set_nested.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    set.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   let val = #("alice", #(30, "engineer"), [1, 2, 3])
   let assert Ok(Nil) = set.insert(table, "user", val)
   let assert Ok(result) = set.lookup(table, key: "user")
   result |> expect.to_equal(val)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_dict_values_test() {
+pub fn set_dict_values_test() -> Nil {
   let path = "test_set_dict_vals.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    set.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   let d = dict.from_list([#("a", 1), #("b", 2)])
   let assert Ok(Nil) = set.insert(table, "config", d)
   let assert Ok(result) = set.lookup(table, key: "config")
   result |> dict.get("a") |> expect.to_equal(Ok(1))
   result |> dict.get("b") |> expect.to_equal(Ok(2))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_result_values_test() {
+pub fn set_result_values_test() -> Nil {
   let path = "test_set_result_vals.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    set.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   let assert Ok(Nil) = set.insert(table, "success", Ok(42))
   let assert Ok(Nil) = set.insert(table, "failure", Error("bad"))
   let assert Ok(Ok(42)) = set.lookup(table, key: "success")
   let assert Ok(Error("bad")) = set.lookup(table, key: "failure")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Large dataset ──────────────────────────────────────────────────
 
-pub fn set_large_dataset_test() {
+pub fn set_large_dataset_test() -> Nil {
   let path = "test_set_large.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   // Insert 1000 entries
   let entries =
-    range(0, 999)
+    test_helpers.range(0, 999)
     |> list.map(fn(i) { #(int.to_string(i), i * i) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   // Verify size
@@ -431,15 +447,15 @@ pub fn set_large_dataset_test() {
   // Sum of i^2 from 0 to 999 = 999*1000*1999/6 = 332_833_500
   sum |> expect.to_equal(332_833_500)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_large_persistence_test() {
+pub fn set_large_persistence_test() -> Nil {
   let path = "test_set_large_persist.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.int, value_decoder: decode.string)
   let entries =
-    range(0, 499)
+    test_helpers.range(0, 499)
     |> list.map(fn(i) { #(i, "value_" <> int.to_string(i)) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   let assert Ok(Nil) = set.close(table)
@@ -450,12 +466,12 @@ pub fn set_large_persistence_test() {
   let assert Ok("value_0") = set.lookup(table2, key: 0)
   let assert Ok("value_499") = set.lookup(table2, key: 499)
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Repair policies ────────────────────────────────────────────────
 
-pub fn set_force_repair_test() {
+pub fn set_force_repair_test() -> Nil {
   let path = "test_set_force_repair.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -471,10 +487,10 @@ pub fn set_force_repair_test() {
     )
   let assert Ok("val") = set.lookup(table2, key: "key")
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_no_repair_test() {
+pub fn set_no_repair_test() -> Nil {
   let path = "test_set_no_repair.dets"
   // Create and properly close a table
   let assert Ok(table) =
@@ -491,12 +507,12 @@ pub fn set_no_repair_test() {
     )
   let assert Ok("val") = set.lookup(table2, key: "key")
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Concurrent access ──────────────────────────────────────────────
 
-pub fn set_shared_access_test() {
+pub fn set_shared_access_test() -> Nil {
   let path = "test_set_shared.dets"
   // Multiple opens of the same file share the table
   let assert Ok(t1) =
@@ -511,10 +527,10 @@ pub fn set_shared_access_test() {
   // Close both (DETS ref-counts, last close does the actual close)
   let assert Ok(Nil) = set.close(t1)
   let assert Ok(Nil) = set.close(t2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_concurrent_writers_test() {
+pub fn set_concurrent_writers_test() -> Nil {
   let path = "test_set_concurrent.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -522,51 +538,53 @@ pub fn set_concurrent_writers_test() {
   let assert Ok(Nil) =
     set.insert_list(
       table,
-      range(0, 99) |> list.map(fn(i) { #("a_" <> int.to_string(i), i) }),
+      test_helpers.range(0, 99)
+        |> list.map(fn(i) { #("a_" <> int.to_string(i), i) }),
     )
   let assert Ok(Nil) =
     set.insert_list(
       table,
-      range(0, 99) |> list.map(fn(i) { #("b_" <> int.to_string(i), i) }),
+      test_helpers.range(0, 99)
+        |> list.map(fn(i) { #("b_" <> int.to_string(i), i) }),
     )
   set.size(table) |> expect.to_equal(Ok(200))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: Edge cases ─────────────────────────────────────────────────────
 
-pub fn set_empty_string_key_test() {
+pub fn set_empty_string_key_test() -> Nil {
   let path = "test_set_empty_key.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, "", "empty_key")
   let assert Ok("empty_key") = set.lookup(table, key: "")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_empty_string_value_test() {
+pub fn set_empty_string_value_test() -> Nil {
   let path = "test_set_empty_val.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.insert(table, "key", "")
   let assert Ok("") = set.lookup(table, key: "key")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_delete_nonexistent_key_test() {
+pub fn set_delete_nonexistent_key_test() -> Nil {
   let path = "test_set_del_missing.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   // Deleting a non-existent key should succeed silently
   let assert Ok(Nil) = set.delete_key(table, key: "nope")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_insert_new_after_delete_test() {
+pub fn set_insert_new_after_delete_test() -> Nil {
   let path = "test_set_new_after_del.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -576,39 +594,39 @@ pub fn set_insert_new_after_delete_test() {
   let assert Ok(Nil) = set.insert_new(table, "key", "second")
   let assert Ok("second") = set.lookup(table, key: "key")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_fold_empty_table_test() {
+pub fn set_fold_empty_table_test() -> Nil {
   let path = "test_set_fold_empty.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let assert Ok(result) = set.fold(table, 0, fn(acc, _k, _v) { acc + 1 })
   result |> expect.to_equal(0)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_to_list_empty_test() {
+pub fn set_to_list_empty_test() -> Nil {
   let path = "test_set_to_list_empty.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   set.to_list(table) |> expect.to_equal(Ok([]))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_insert_list_empty_test() {
+pub fn set_insert_list_empty_test() -> Nil {
   let path = "test_set_insert_list_empty.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let assert Ok(Nil) = set.insert_list(table, [])
   set.size(table) |> expect.to_equal(Ok(0))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_multiple_close_reopen_cycles_test() {
+pub fn set_multiple_close_reopen_cycles_test() -> Nil {
   let path = "test_set_cycles.dets"
   // Cycle 1: write
   let assert Ok(t) =
@@ -626,10 +644,10 @@ pub fn set_multiple_close_reopen_cycles_test() {
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let assert Ok(2) = set.lookup(t, key: "round")
   let assert Ok(Nil) = set.close(t)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_with_table_error_still_closes_test() {
+pub fn set_with_table_error_still_closes_test() -> Nil {
   let path = "test_set_with_err.dets"
   // with_table should close even when callback returns Error
   let result =
@@ -644,10 +662,10 @@ pub fn set_with_table_error_still_closes_test() {
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_info_grows_with_data_test() {
+pub fn set_info_grows_with_data_test() -> Nil {
   let path = "test_set_info_grow.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -655,17 +673,17 @@ pub fn set_info_grows_with_data_test() {
   let initial_size = info1.file_size
   // Insert substantial data
   let entries =
-    range(0, 199)
+    test_helpers.range(0, 199)
     |> list.map(fn(i) { #(int.to_string(i), string.repeat("x", 100)) })
   let assert Ok(Nil) = set.insert_list(table, entries)
   let assert Ok(info2) = set.info(table)
   info2.object_count |> expect.to_equal(200)
   { info2.file_size > initial_size } |> expect.to_be_true
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_overwrite_preserves_size_test() {
+pub fn set_overwrite_preserves_size_test() -> Nil {
   let path = "test_set_overwrite_size.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.string)
@@ -675,10 +693,10 @@ pub fn set_overwrite_preserves_size_test() {
   // Size should be 1 — sets overwrite, not accumulate
   set.size(table) |> expect.to_equal(Ok(1))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_fold_collects_all_keys_test() {
+pub fn set_fold_collects_all_keys_test() -> Nil {
   let path = "test_set_fold_keys.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -686,5 +704,5 @@ pub fn set_fold_collects_all_keys_test() {
   let assert Ok(keys) = set.fold(table, [], fn(acc, key, _val) { [key, ..acc] })
   keys |> list.sort(string.compare) |> expect.to_equal(["a", "b", "c"])
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/slate_test.gleam
+++ b/test/slate_test.gleam
@@ -1,5 +1,5 @@
 import startest
 
-pub fn main() {
+pub fn main() -> Nil {
   startest.run(startest.default_config())
 }

--- a/test/test_helpers.gleam
+++ b/test/test_helpers.gleam
@@ -1,8 +1,8 @@
 import gleam/dynamic/decode.{type Decoder, type Dynamic}
-import gleam/list
+import gleam/int
 
 /// Delete a test file, ignoring any deletion error.
-pub fn cleanup(path: String) {
+pub fn cleanup(path: String) -> Nil {
   let _ = delete_file(path)
   Nil
 }
@@ -17,13 +17,15 @@ pub fn is_table_open(path: String) -> Bool {
   ffi_is_table_open(path)
 }
 
-/// Build an inclusive integer range from `from` to `to`.
+/// Build an inclusive ascending integer range from `from` to `to`.
 ///
-/// Returns an empty list when `from > to`.
+/// Thin wrapper over `int.range`, which replaced the deprecated
+/// `list.range`. Returns an empty list when `from > to`.
 pub fn range(from: Int, to: Int) -> List(Int) {
   case from > to {
     True -> []
-    False -> range_loop(from, to, [])
+    False ->
+      int.range(from: to, to: from - 1, with: [], run: fn(acc, i) { [i, ..acc] })
   }
 }
 
@@ -36,18 +38,11 @@ pub fn unsafe_decoder() -> Decoder(a) {
   decode.new_primitive_decoder("unsafe", fn(dyn) { Ok(unsafe_coerce(dyn)) })
 }
 
-fn range_loop(current: Int, to: Int, acc: List(Int)) -> List(Int) {
-  case current > to {
-    True -> list.reverse(acc)
-    False -> range_loop(current + 1, to, [current, ..acc])
-  }
-}
-
 @external(erlang, "file", "delete")
-fn delete_file(path: String) -> Result(Nil, DynError)
+fn delete_file(path: String) -> Result(Nil, DynamicError)
 
 /// Dynamic Erlang error returned by `file:delete/1`.
-type DynError
+type DynamicError
 
 @external(erlang, "test_helpers_ffi", "did_panic")
 fn ffi_did_panic(fun: fn() -> a) -> Bool

--- a/test/test_helpers_test.gleam
+++ b/test/test_helpers_test.gleam
@@ -1,14 +1,18 @@
 import startest/expect
 import test_helpers
 
-pub fn range_inclusive_test() {
+pub fn range_inclusive_test() -> Nil {
   test_helpers.range(1, 3) |> expect.to_equal([1, 2, 3])
 }
 
-pub fn range_empty_when_from_gt_to_test() {
+pub fn range_single_element_test() -> Nil {
+  test_helpers.range(5, 5) |> expect.to_equal([5])
+}
+
+pub fn range_empty_when_from_gt_to_test() -> Nil {
   test_helpers.range(3, 1) |> expect.to_equal([])
 }
 
-pub fn cleanup_missing_file_test() {
+pub fn cleanup_missing_file_test() -> Nil {
   test_helpers.cleanup("test_helpers_missing_file.dets") |> expect.to_equal(Nil)
 }

--- a/test/type_safety_test.gleam
+++ b/test/type_safety_test.gleam
@@ -1,19 +1,20 @@
-/// Tests verifying runtime type safety via decoders.
-///
-/// These tests confirm that opening a DETS file with the wrong type
-/// decoders produces DecodeErrors instead of silently returning
-/// incorrectly-typed data.
+//// Tests verifying runtime type safety via decoders.
+////
+//// These tests confirm that opening a DETS file with the wrong type
+//// decoders produces DecodeErrors instead of silently returning
+//// incorrectly-typed data.
+
 import gleam/dynamic/decode
 import slate
 import slate/bag
 import slate/duplicate_bag
 import slate/set
 import startest/expect
-import test_helpers.{cleanup}
+import test_helpers
 
 // ── Set: wrong value decoder ────────────────────────────────────────────
 
-pub fn set_wrong_value_decoder_lookup_test() {
+pub fn set_wrong_value_decoder_lookup_test() -> Nil {
   let path = "test_ts_set_wrong_val.dets"
   // Write as String/Int
   let assert Ok(table) =
@@ -29,10 +30,10 @@ pub fn set_wrong_value_decoder_lookup_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_wrong_value_decoder_to_list_test() {
+pub fn set_wrong_value_decoder_to_list_test() -> Nil {
   let path = "test_ts_set_wrong_to_list.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -48,10 +49,10 @@ pub fn set_wrong_value_decoder_to_list_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn set_wrong_value_decoder_fold_test() {
+pub fn set_wrong_value_decoder_fold_test() -> Nil {
   let path = "test_ts_set_wrong_fold.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -66,12 +67,12 @@ pub fn set_wrong_value_decoder_fold_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Set: correct decoders still work ────────────────────────────────────
 
-pub fn set_correct_decoders_work_test() {
+pub fn set_correct_decoders_work_test() -> Nil {
   let path = "test_ts_set_correct.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -86,12 +87,12 @@ pub fn set_correct_decoders_work_test() {
   let assert Ok(sum) = set.fold(table2, 0, fn(acc, _k, v) { acc + v })
   sum |> expect.to_equal(99)
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Bag: wrong value decoder ────────────────────────────────────────────
 
-pub fn bag_wrong_value_decoder_lookup_test() {
+pub fn bag_wrong_value_decoder_lookup_test() -> Nil {
   let path = "test_ts_bag_wrong_val.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -107,10 +108,10 @@ pub fn bag_wrong_value_decoder_lookup_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn bag_wrong_value_decoder_fold_test() {
+pub fn bag_wrong_value_decoder_fold_test() -> Nil {
   let path = "test_ts_bag_wrong_fold.dets"
   let assert Ok(table) =
     bag.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -124,12 +125,12 @@ pub fn bag_wrong_value_decoder_fold_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── DuplicateBag: wrong value decoder ───────────────────────────────────
 
-pub fn dupbag_wrong_value_decoder_lookup_test() {
+pub fn dupbag_wrong_value_decoder_lookup_test() -> Nil {
   let path = "test_ts_dupbag_wrong_val.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -153,10 +154,10 @@ pub fn dupbag_wrong_value_decoder_lookup_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn dupbag_wrong_value_decoder_to_list_test() {
+pub fn dupbag_wrong_value_decoder_to_list_test() -> Nil {
   let path = "test_ts_dupbag_wrong_to_list.dets"
   let assert Ok(table) =
     duplicate_bag.open(
@@ -178,12 +179,12 @@ pub fn dupbag_wrong_value_decoder_to_list_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = duplicate_bag.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Wrong key decoder ───────────────────────────────────────────────────
 
-pub fn set_wrong_key_decoder_to_list_test() {
+pub fn set_wrong_key_decoder_to_list_test() -> Nil {
   let path = "test_ts_set_wrong_key.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -198,5 +199,5 @@ pub fn set_wrong_key_decoder_to_list_test() {
     other -> other |> expect.to_equal(Error(slate.NotFound))
   }
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }

--- a/test/update_counter_test.gleam
+++ b/test/update_counter_test.gleam
@@ -1,14 +1,15 @@
-/// Tests for update_counter API on set tables.
-/// Adapted from OTP dets_SUITE update_counter test.
+//// Tests for update_counter API on set tables.
+//// Adapted from OTP dets_SUITE update_counter test.
+
 import gleam/dynamic/decode
 import slate
 import slate/set
 import startest/expect
-import test_helpers.{cleanup, unsafe_decoder}
+import test_helpers
 
 // ── Basic increment ─────────────────────────────────────────────────────
 
-pub fn update_counter_basic_test() {
+pub fn update_counter_basic_test() -> Nil {
   let path = "test_counter_basic.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -19,12 +20,12 @@ pub fn update_counter_basic_test() {
   // Verify via lookup
   let assert Ok(3) = set.lookup(table, key: "hits")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Increment by various amounts ────────────────────────────────────────
 
-pub fn update_counter_by_amount_test() {
+pub fn update_counter_by_amount_test() -> Nil {
   let path = "test_counter_amount.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -33,12 +34,12 @@ pub fn update_counter_by_amount_test() {
   let assert Ok(110) = set.update_counter(table, "score", 100)
   let assert Ok(110) = set.lookup(table, key: "score")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Negative increment (decrement) ──────────────────────────────────────
 
-pub fn update_counter_decrement_test() {
+pub fn update_counter_decrement_test() -> Nil {
   let path = "test_counter_dec.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -47,12 +48,12 @@ pub fn update_counter_decrement_test() {
   let assert Ok(50) = set.update_counter(table, "balance", -25)
   let assert Ok(50) = set.lookup(table, key: "balance")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Counter goes negative ───────────────────────────────────────────────
 
-pub fn update_counter_goes_negative_test() {
+pub fn update_counter_goes_negative_test() -> Nil {
   let path = "test_counter_neg.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -60,12 +61,12 @@ pub fn update_counter_goes_negative_test() {
   let assert Ok(-10) = set.update_counter(table, "temp", -10)
   let assert Ok(-10) = set.lookup(table, key: "temp")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Counter persists across close/reopen ────────────────────────────────
 
-pub fn update_counter_persistence_test() {
+pub fn update_counter_persistence_test() -> Nil {
   let path = "test_counter_persist.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -79,22 +80,22 @@ pub fn update_counter_persistence_test() {
   let assert Ok(8) = set.update_counter(table2, "counter", 3)
   let assert Ok(8) = set.lookup(table2, key: "counter")
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Counter with non-existent key fails ─────────────────────────────────
 
-pub fn update_counter_missing_key_test() {
+pub fn update_counter_missing_key_test() -> Nil {
   let path = "test_counter_missing.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
   let result = set.update_counter(table, "missing", 1)
   result |> expect.to_equal(Error(set.TableError(slate.NotFound)))
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
-pub fn update_counter_closed_table_test() {
+pub fn update_counter_closed_table_test() -> Nil {
   let path = "test_counter_closed.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -104,12 +105,12 @@ pub fn update_counter_closed_table_test() {
   set.update_counter(table, "hits", 1)
   |> expect.to_equal(Error(set.TableError(slate.TableDoesNotExist)))
 
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Increment by zero ───────────────────────────────────────────────────
 
-pub fn update_counter_by_zero_test() {
+pub fn update_counter_by_zero_test() -> Nil {
   let path = "test_counter_zero.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -117,12 +118,12 @@ pub fn update_counter_by_zero_test() {
   let assert Ok(42) = set.update_counter(table, "stable", 0)
   let assert Ok(42) = set.lookup(table, key: "stable")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Multiple counters in same table ─────────────────────────────────────
 
-pub fn update_counter_multiple_keys_test() {
+pub fn update_counter_multiple_keys_test() -> Nil {
   let path = "test_counter_multi.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -139,12 +140,12 @@ pub fn update_counter_multiple_keys_test() {
   let assert Ok(1) = set.lookup(table, key: "api_calls")
   let assert Ok(3) = set.lookup(table, key: "errors")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Large increment ─────────────────────────────────────────────────────
 
-pub fn update_counter_large_increment_test() {
+pub fn update_counter_large_increment_test() -> Nil {
   let path = "test_counter_large.dets"
   let assert Ok(table) =
     set.open(path, key_decoder: decode.string, value_decoder: decode.int)
@@ -153,15 +154,19 @@ pub fn update_counter_large_increment_test() {
   let assert Ok(2_000_000) = set.update_counter(table, "big", 1_000_000)
   let assert Ok(2_000_000) = set.lookup(table, key: "big")
   let assert Ok(Nil) = set.close(table)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }
 
 // ── Counter with non-integer value fails ─────────────────────────────────
 
-pub fn update_counter_non_integer_value_test() {
+pub fn update_counter_non_integer_value_test() -> Nil {
   let path = "test_counter_nonint.dets"
   let assert Ok(table) =
-    set.open(path, key_decoder: decode.string, value_decoder: unsafe_decoder())
+    set.open(
+      path,
+      key_decoder: decode.string,
+      value_decoder: test_helpers.unsafe_decoder(),
+    )
   let assert Ok(Nil) = set.insert(table, "hits", "not_an_int")
   let assert Ok(Nil) = set.close(table)
 
@@ -170,5 +175,5 @@ pub fn update_counter_non_integer_value_test() {
   let result = set.update_counter(table2, "hits", 1)
   result |> expect.to_equal(Error(set.CounterValueNotInteger))
   let assert Ok(Nil) = set.close(table2)
-  cleanup(path)
+  test_helpers.cleanup(path)
 }


### PR DESCRIPTION
## Summary

Non-breaking fixes from a review against the [Gleam conventions guide](https://gleam.run/documentation/conventions-patterns-and-anti-patterns/). The one breaking suggestion from that review (context fields on `DetsError` variants) is tracked separately in #81.

### User-facing fix
- **Module docs now render on HexDocs**: every module header used `///` (definition docs) instead of `////` (module docs), so the package documentation — including the Quick Start and Limitations sections in `slate.gleam` — was silently dropped from `gleam docs build`.

### Style cleanup (no API changes)
- Qualified `test_helpers` imports in all 16 test modules instead of unqualified function imports.
- Return annotations (`-> Nil`) on all test functions and helpers.
- `test_helpers.range` rebuilt as a thin wrapper over `int.range` (`list.range` is deprecated in the current stdlib), replacing the hand-rolled recursive loop.
- `ffi_error_test`: two tests had catch-all branches accepting every possible outcome (including `Ok`) and could never fail; they now assert `Error(NotADetsFile)` / `Error(NeedsRepair)` exactly.
- Renamed abbreviations: `dv` → `dynamic_value` (src), `DynError` → `DynamicError` (test helper).
- Moved a stray `import gleam/list` from the bottom of `corruption_test.gleam` to the import block.

## Testing

`just ci` passes: format check, type check, 275/275 tests, and `gleam build --warnings-as-errors` (confirms no deprecation warnings remain).