### PR TITLE
ci: push release tags with the release app token

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -7,10 +7,15 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   auto-tag:
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@ed7d5e5f1d4370a5ccf06503916e3c301102ab1c # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
       tag-prefix: v
       create-release: true
+    # The app token makes the tag push trigger publish.yml; a GITHUB_TOKEN push does not.
+    secrets:
+      app-id: ${{ secrets.RELEASE_APP_ID }}
+      app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: tylerbutler/actions/changie-check@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/changie-check@main
+      - uses: tylerbutler/actions/changie-check@ed7d5e5f1d4370a5ccf06503916e3c301102ab1c # ratchet:tylerbutler/actions/changie-check@main
         id: changelog
         with:
           base-sha: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: tylerbutler/actions/changie-release@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/changie-release@main
+      - uses: tylerbutler/actions/changie-release@ed7d5e5f1d4370a5ccf06503916e3c301102ab1c # ratchet:tylerbutler/actions/changie-release@main
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

`v1.0.1` was tagged by `auto-tag.yml` but **never published to Hex** — hex.pm still shows `1.0.0` as latest. Tags pushed with the default `GITHUB_TOKEN` do not trigger other workflows, so the tag push never fired `publish.yml`.

(v1.0.0 published only because that tag was pushed manually — auto-tag was creating unprefixed `1.0.0` tags at the time, fixed later in #71.)

## Changes

- Bump all three `tylerbutler/actions` pins from `c697a81` (2026-02-17) to `ed7d5e5` (2026-07-07). The old pin predates optional app-token support, added upstream in tylerbutler/actions#8 on 2026-03-01.
- Pass `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` to the auto-tag reusable workflow. It generates an app token, checks out with it, and passes it to `changie-auto-tag` — so the tag push is authenticated as the app and triggers `publish.yml`.
- Add `actions: read` to the caller's `permissions`. The reusable workflow declares it, and a called workflow cannot hold permissions the caller did not grant.

`release.yml` and `pr.yml` are pin bumps only — verified input/output compatible with `ed7d5e5` (`changie-check`: `base-sha`/`head-sha` → `has-entries`/`preview`/`needs-entry`/`commit-types-found`; `changie-release`: `token`/`pr-title-template`/`version-files` → `skipped`/`version`/`pr-url`/`pr-operation`).
